### PR TITLE
fix: increase maxDuration to 300s for Fluid Compute

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { streamText, convertToModelMessages } from 'ai';
 import { getAIModel } from '@/lib/ai-providers';
 import { z } from "zod";
 
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 export async function POST(req: Request) {
   try {


### PR DESCRIPTION
## Summary
- Increases `maxDuration` from 60s to 300s in the chat API route
- Takes advantage of Vercel's Fluid Compute feature which allows up to 300s even on Hobby plan
- Fixes timeout errors when using slower models like Claude Opus 4.5 via Bedrock

## Context
With Fluid Compute enabled (default for new projects, manually enabled for existing ones), the Hobby plan supports up to 300s function duration instead of the previous 60s limit.