### PR TITLE
feat: add DeepSeek as AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Diagrams are represented as XML that can be rendered in draw.io. The AI processe
 -   Google AI
 -   Azure OpenAI
 -   Ollama
+-   OpenRouter
+-   DeepSeek
 
 Note that `claude-sonnet-4-5` has trained on draw.io diagrams with AWS logos, so if you want to create AWS architecture diagrams, this is the best choice.
 
@@ -105,7 +107,7 @@ cp env.example .env.local
 
 Edit `.env.local` and configure your chosen provider:
 
--   Set `AI_PROVIDER` to your chosen provider (bedrock, openai, anthropic, google, azure, ollama)
+-   Set `AI_PROVIDER` to your chosen provider (bedrock, openai, anthropic, google, azure, ollama, openrouter, deepseek)
 -   Set `AI_MODEL` to the specific model you want to use
 -   Add the required API keys for your provider
 

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # AI Provider Configuration
 # AI_PROVIDER: Which provider to use
-# Options: bedrock, openai, anthropic, google, azure, ollama, openrouter
+# Options: bedrock, openai, anthropic, google, azure, ollama, openrouter, deepseek
 # Default: bedrock
 AI_PROVIDER=bedrock
 
@@ -37,3 +37,7 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 # OpenRouter Configuration
 # OPENROUTER_API_KEY=sk-or-v1-...
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1  # Optional: Custom endpoint
+
+# DeepSeek Configuration
+# DEEPSEEK_API_KEY=sk-...
+# DEEPSEEK_BASE_URL=https://api.deepseek.com/v1  # Optional: Custom endpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@ai-sdk/amazon-bedrock": "^3.0.62",
                 "@ai-sdk/anthropic": "^2.0.44",
                 "@ai-sdk/azure": "^2.0.69",
+                "@ai-sdk/deepseek": "^1.0.30",
                 "@ai-sdk/google": "^2.0.0",
                 "@ai-sdk/openai": "^2.0.19",
                 "@ai-sdk/react": "^2.0.22",
@@ -155,6 +156,40 @@
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
+        "node_modules/@ai-sdk/deepseek": {
+            "version": "1.0.30",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-1.0.30.tgz",
+            "integrity": "sha512-pafNclW9L8Z3WimaRwlpHrGbdeaDE/UklT3rMi2aoRRyrA+s7zGcFuu1zbO2ViLNlKfaS91XZa9MFAPXbIftUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/openai-compatible": "1.0.28",
+                "@ai-sdk/provider": "2.0.0",
+                "@ai-sdk/provider-utils": "3.0.18"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider-utils": {
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
+            "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "2.0.0",
+                "@standard-schema/spec": "^1.0.0",
+                "eventsource-parser": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
         "node_modules/@ai-sdk/gateway": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.7.tgz",
@@ -223,6 +258,39 @@
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
                 "@ai-sdk/provider-utils": "3.0.17"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/openai-compatible": {
+            "version": "1.0.28",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.28.tgz",
+            "integrity": "sha512-yKubDxLYtXyGUzkr9lNStf/lE/I+Okc8tmotvyABhsQHHieLKk6oV5fJeRJxhr67Ejhg+FRnwUOxAmjRoFM4dA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "2.0.0",
+                "@ai-sdk/provider-utils": "3.0.18"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
+            "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "2.0.0",
+                "@standard-schema/spec": "^1.0.0",
+                "eventsource-parser": "^3.0.6"
             },
             "engines": {
                 "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@ai-sdk/amazon-bedrock": "^3.0.62",
         "@ai-sdk/anthropic": "^2.0.44",
         "@ai-sdk/azure": "^2.0.69",
+        "@ai-sdk/deepseek": "^1.0.30",
         "@ai-sdk/google": "^2.0.0",
         "@ai-sdk/openai": "^2.0.19",
         "@ai-sdk/react": "^2.0.22",


### PR DESCRIPTION
## Summary

- Add DeepSeek provider support to the application
- Install @ai-sdk/deepseek package
- Update provider configuration and documentation

Closes #37

## Changes

### Code Changes
- Added DeepSeek imports to `lib/ai-providers.ts`
- Added `'deepseek'` to `ProviderName` type
- Added `DEEPSEEK_API_KEY` validation
- Implemented DeepSeek provider in switch case with support for custom base URL
- Updated JSDoc comments to include DeepSeek configuration

### Documentation Changes
- Added DeepSeek to `env.example` with configuration examples
- Updated `README.md` to list DeepSeek in Multi-Provider Support section
- Updated configuration instructions to include `deepseek` in provider options

## Implementation Details

The DeepSeek provider follows the same pattern as other providers (OpenAI, Google, Azure):
- Default usage: `deepseek(modelId)`
- Custom base URL: `createDeepSeek({ apiKey, baseURL })`

## Testing

Tested with:
- AI_PROVIDER=deepseek
- AI_MODEL=deepseek-chat
- DEEPSEEK_API_KEY configured

## Related

- Implements DeepSeek provider as requested
- Follows existing provider patterns for consistency