### PR TITLE
feat: improve diagram edit tracking and cache handling

### DIFF
--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -44,7 +44,6 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
     const getLastAgentGeneratedXml = () => lastAgentGeneratedXmlRef.current;
 
     const markAgentDiagramPending = () => {
-        console.log('[DiagramContext] markAgentDiagramPending called');
         agentDiagramPendingRef.current = true;
     };
 
@@ -80,7 +79,6 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         // This ensures we compare apples-to-apples (both formatted the same way)
         if (agentDiagramPendingRef.current) {
             const formatted = formatXML(extractedXML);
-            console.log('[DiagramContext] Setting lastAgentGeneratedXml from export, length:', formatted.length);
             setLastAgentGeneratedXml(formatted);
             agentDiagramPendingRef.current = false;
         }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -190,15 +190,9 @@ export function replaceXMLParts(
   let result = formatXML(xmlContent);
   let lastProcessedIndex = 0;
 
-  console.log('[replaceXMLParts] Input XML length:', xmlContent.length);
-  console.log('[replaceXMLParts] Formatted XML length:', result.length);
-  console.log('[replaceXMLParts] Number of edits:', searchReplacePairs.length);
-
   for (const { search, replace } of searchReplacePairs) {
     // Also format the search content for consistency
     const formattedSearch = formatXML(search);
-    console.log('[replaceXMLParts] Search pattern (first 200):', search.substring(0, 200));
-    console.log('[replaceXMLParts] Formatted search (first 200):', formattedSearch.substring(0, 200));
     const searchLines = formattedSearch.split('\n');
 
     // Split into lines for exact line matching
@@ -282,9 +276,6 @@ export function replaceXMLParts(
     }
 
     if (!matchFound) {
-      console.log('[replaceXMLParts] SEARCH FAILED!');
-      console.log('[replaceXMLParts] Current XML content:\n', result);
-      console.log('[replaceXMLParts] Search pattern:\n', formattedSearch);
       throw new Error(`Search pattern not found in the diagram. The pattern may not exist in the current structure.`);
     }
 


### PR DESCRIPTION
## Summary

- Track `lastGeneratedXml` to detect user modifications to diagrams
- Only send XML context to AI when needed (saves tokens)
- Fix cached response streaming to include tool output for follow-up conversations
- Enable multi-step tool execution with `maxSteps: 5`

### Code quality fixes (after review):
- Remove verbose debug console.logs (kept only token usage log)
- Add basic input validation for messages array  
- Fix XML comparison using `formatXML` for consistency
- Extract `CACHED_TOOL_PREFIX` constant to avoid magic string
- Fix `addToolResult` API to use correct `tool`/`output` params

## Test plan

- [x] TypeScript compilation passes
- [ ] Test creating new diagram from scratch
- [ ] Test follow-up conversation after cached response
- [ ] Test user-modified diagram detection
- [ ] Test edit_diagram with multiple edits