### PR TITLE
fix: show user-friendly error when model doesn't support images

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -331,15 +331,20 @@ IMPORTANT: Keep edits concise:
         return 'unknown error';
       }
 
-      if (typeof error === 'string') {
-        return error;
+      const errorString = typeof error === 'string'
+        ? error
+        : error instanceof Error
+          ? error.message
+          : JSON.stringify(error);
+
+      // Check for image not supported error (e.g., DeepSeek models)
+      if (errorString.includes('image_url') ||
+          errorString.includes('unknown variant') ||
+          (errorString.includes('image') && errorString.includes('not supported'))) {
+        return 'This model does not support image inputs. Please remove the image and try again, or switch to a vision-capable model.';
       }
 
-      if (error instanceof Error) {
-        return error.message;
-      }
-
-      return JSON.stringify(error);
+      return errorString;
     }
 
     return result.toUIMessageStreamResponse({


### PR DESCRIPTION
## Summary
- Adds graceful error handling when models that don't support images (e.g., DeepSeek deepseek-chat, deepseek-reasoner) receive image inputs
- Detects the cryptic `unknown variant image_url` error and shows a clear user-friendly message instead

Fixes #42

## Changes
- Modified error handler in `app/api/chat/route.ts` to detect image-related errors
- Returns helpful message: "This model does not support image inputs. Please remove the image and try again, or switch to a vision-capable model."