### PR TITLE
fix: use static sha- prefix for Docker tags and add Docker run instructions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,7 +50,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ Note that `claude-sonnet-4-5` has trained on draw.io diagrams with AWS logos, so
 
 ## Getting Started
 
+### Run with Docker (Recommended)
+
+If you just want to run it locally, the best way is to use Docker.
+
+First, install Docker if you haven't already: [Get Docker](https://docs.docker.com/get-docker/)
+
+Then run:
+
+```bash
+docker run -d -p 3000:3000 \
+  -e AI_PROVIDER=openai \
+  -e AI_MODEL=gpt-4o \
+  -e OPENAI_API_KEY=your_api_key \
+  ghcr.io/dayuanjiang/next-ai-draw-io:latest
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+Replace the environment variables with your preferred AI provider configuration. See [Multi-Provider Support](#multi-provider-support) for available options.
+
 ### Installation
 
 1. Clone the repository:

--- a/README_CN.md
+++ b/README_CN.md
@@ -93,6 +93,26 @@ https://github.com/user-attachments/assets/b2eef5f3-b335-4e71-a755-dc2e80931979
 
 ## 快速开始
 
+### 使用Docker运行（推荐）
+
+如果您只想在本地运行，最好的方式是使用Docker。
+
+首先，如果您还没有安装Docker，请先安装：[获取Docker](https://docs.docker.com/get-docker/)
+
+然后运行：
+
+```bash
+docker run -d -p 3000:3000 \
+  -e AI_PROVIDER=openai \
+  -e AI_MODEL=gpt-4o \
+  -e OPENAI_API_KEY=your_api_key \
+  ghcr.io/dayuanjiang/next-ai-draw-io:latest
+```
+
+在浏览器中打开 [http://localhost:3000](http://localhost:3000)。
+
+请根据您首选的AI提供商配置替换环境变量。可用选项请参阅[多提供商支持](#多提供商支持)。
+
 ### 安装
 
 1. 克隆仓库：

--- a/README_JA.md
+++ b/README_JA.md
@@ -93,6 +93,26 @@ https://github.com/user-attachments/assets/b2eef5f3-b335-4e71-a755-dc2e80931979
 
 ## はじめに
 
+### Dockerで実行（推奨）
+
+ローカルで実行したいだけなら、Dockerを使用するのが最も簡単です。
+
+まず、Dockerをインストールしていない場合はインストールしてください：[Dockerを入手](https://docs.docker.com/get-docker/)
+
+次に実行：
+
+```bash
+docker run -d -p 3000:3000 \
+  -e AI_PROVIDER=openai \
+  -e AI_MODEL=gpt-4o \
+  -e OPENAI_API_KEY=your_api_key \
+  ghcr.io/dayuanjiang/next-ai-draw-io:latest
+```
+
+ブラウザで [http://localhost:3000](http://localhost:3000) を開いてください。
+
+環境変数はお好みのAIプロバイダー設定に置き換えてください。利用可能なオプションについては[マルチプロバイダーサポート](#マルチプロバイダーサポート)を参照してください。
+
 ### インストール
 
 1. リポジトリをクローン：


### PR DESCRIPTION
## Summary
- Fixed Docker workflow that was failing on every PR due to invalid tags like `-66c3202` (starting with hyphen)
- Changed `type=sha,prefix={{branch}}-` to `type=sha,prefix=sha-` to produce valid tags like `sha-66c3202`
- Added Docker run instructions to README (EN/CN/JA) with link to official Docker installation docs