### PR TITLE
fix: prevent duplicate history entries when edit_diagram tool is called

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -27,18 +27,23 @@ export default function ChatPanel({
     const {
         loadDiagram: onDisplayChart,
         handleExport: onExport,
+        handleExportWithoutHistory,
         resolverRef,
         chartXML,
         clearDiagram,
     } = useDiagram();
 
-    const onFetchChart = () => {
+    const onFetchChart = (saveToHistory = true) => {
         return Promise.race([
             new Promise<string>((resolve) => {
                 if (resolverRef && "current" in resolverRef) {
                     resolverRef.current = resolve;
                 }
-                onExport();
+                if (saveToHistory) {
+                    onExport();
+                } else {
+                    handleExportWithoutHistory();
+                }
             }),
             new Promise<string>((_, reject) =>
                 setTimeout(
@@ -87,7 +92,8 @@ export default function ChatPanel({
 
                     let currentXml = "";
                     try {
-                        currentXml = await onFetchChart();
+                        // Fetch without saving to history - edit_diagram shouldn't create history entry
+                        currentXml = await onFetchChart(false);
 
                         const { replaceXMLParts } = await import("@/lib/utils");
                         const editedXml = replaceXMLParts(currentXml, edits);

--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -10,6 +10,7 @@ interface DiagramContextType {
     diagramHistory: { svg: string; xml: string }[];
     loadDiagram: (chart: string) => void;
     handleExport: () => void;
+    handleExportWithoutHistory: () => void;
     resolverRef: React.Ref<((value: string) => void) | null>;
     drawioRef: React.Ref<DrawIoEmbedRef | null>;
     handleDiagramExport: (data: any) => void;
@@ -36,6 +37,15 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         if (drawioRef.current) {
             // Mark that this export should be saved to history
             expectHistoryExportRef.current = true;
+            drawioRef.current.exportDiagram({
+                format: "xmlsvg",
+            });
+        }
+    };
+
+    const handleExportWithoutHistory = () => {
+        if (drawioRef.current) {
+            // Export without saving to history (for edit_diagram fetching current state)
             drawioRef.current.exportDiagram({
                 format: "xmlsvg",
             });
@@ -124,6 +134,7 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
                 diagramHistory,
                 loadDiagram,
                 handleExport,
+                handleExportWithoutHistory,
                 resolverRef,
                 drawioRef,
                 handleDiagramExport,


### PR DESCRIPTION
## Summary
- Add `handleExportWithoutHistory` function for fetching current diagram state without saving to history
- Update `onFetchChart` to accept `saveToHistory` parameter (defaults to true)
- `edit_diagram` tool now fetches with `saveToHistory=false` since it only needs the current state
- Only the initial form submission saves to history as intended

This fixes the regression introduced in PR #63 where diagram history was being saved twice when using edit_diagram.

## Test plan
- [ ] Send a message and verify only one history entry is added
- [ ] When AI uses edit_diagram tool, verify no additional history entry is created
- [ ] Verify history dialog shows correct number of versions