### PR TITLE
refactor: extract system prompts and add extended prompt for Opus/Haiku 4.5

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -144,9 +144,6 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
         }
     }, [messages]);
 
-    useEffect(() => {
-        console.log("[ChatPanel] Status changed to:", status);
-    }, [status]);
 
     const onFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -21,6 +21,7 @@ interface ModelConfig {
   model: any;
   providerOptions?: any;
   headers?: Record<string, string>;
+  modelId: string;
 }
 
 // Bedrock provider options for Anthropic beta features
@@ -91,7 +92,6 @@ export function getAIModel(): ModelConfig {
   // Validate provider credentials
   validateProviderCredentials(provider);
 
-  // Log initialization for debugging
   console.log(`[AI Provider] Initializing ${provider} with model: ${modelId}`);
 
   let model: any;
@@ -191,10 +191,5 @@ export function getAIModel(): ModelConfig {
       );
   }
 
-  // Log if provider options or headers are being applied
-  if (providerOptions || headers) {
-    console.log('[AI Provider] Applying provider-specific options/headers');
-  }
-
-  return { model, providerOptions, headers };
+  return { model, providerOptions, headers, modelId };
 }

--- a/lib/cached-responses.ts
+++ b/lib/cached-responses.ts
@@ -12,117 +12,117 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
   <mxCell id="0"/>
   <mxCell id="1" parent="0"/>
 
-  <!-- Title -->
+
   <mxCell id="title" value="Transformer Architecture" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=20;fontStyle=1;" vertex="1" parent="1">
     <mxGeometry x="300" y="20" width="250" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Input Embedding (Left - Encoder Side) -->
+
   <mxCell id="input_embed" value="Input Embedding" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="80" y="480" width="120" height="40" as="geometry"/>
   </mxCell>
 
-  <!-- Positional Encoding (Left) -->
+
   <mxCell id="pos_enc_left" value="Positional Encoding" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="80" y="420" width="120" height="40" as="geometry"/>
   </mxCell>
 
-  <!-- Encoder Stack -->
+
   <mxCell id="encoder_box" value="ENCODER" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;verticalAlign=top;fontSize=12;fontStyle=1;" vertex="1" parent="1">
     <mxGeometry x="60" y="180" width="160" height="220" as="geometry"/>
   </mxCell>
 
-  <!-- Multi-Head Attention (Encoder) -->
+
   <mxCell id="mha_enc" value="Multi-Head&#xa;Attention" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="80" y="330" width="120" height="50" as="geometry"/>
   </mxCell>
 
-  <!-- Add & Norm 1 (Encoder) -->
+
   <mxCell id="add_norm1_enc" value="Add &amp; Norm" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="80" y="280" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Feed Forward (Encoder) -->
+
   <mxCell id="ff_enc" value="Feed Forward" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="80" y="240" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Add & Norm 2 (Encoder) -->
+
   <mxCell id="add_norm2_enc" value="Add &amp; Norm" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="80" y="200" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Nx label for encoder -->
+
   <mxCell id="nx_enc" value="Nx" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=11;fontStyle=2;" vertex="1" parent="1">
     <mxGeometry x="30" y="275" width="30" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Output Embedding (Right - Decoder Side) -->
+
   <mxCell id="output_embed" value="Output Embedding" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="650" y="480" width="120" height="40" as="geometry"/>
   </mxCell>
 
-  <!-- Positional Encoding (Right) -->
+
   <mxCell id="pos_enc_right" value="Positional Encoding" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="650" y="420" width="120" height="40" as="geometry"/>
   </mxCell>
 
-  <!-- Decoder Stack -->
+
   <mxCell id="decoder_box" value="DECODER" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;verticalAlign=top;fontSize=12;fontStyle=1;" vertex="1" parent="1">
     <mxGeometry x="630" y="140" width="160" height="260" as="geometry"/>
   </mxCell>
 
-  <!-- Masked Multi-Head Attention (Decoder) -->
+
   <mxCell id="masked_mha_dec" value="Masked Multi-Head&#xa;Attention" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="340" width="120" height="50" as="geometry"/>
   </mxCell>
 
-  <!-- Add & Norm 1 (Decoder) -->
+
   <mxCell id="add_norm1_dec" value="Add &amp; Norm" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="290" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Multi-Head Attention (Decoder - Cross Attention) -->
+
   <mxCell id="mha_dec" value="Multi-Head&#xa;Attention" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="240" width="120" height="40" as="geometry"/>
   </mxCell>
 
-  <!-- Add & Norm 2 (Decoder) -->
+
   <mxCell id="add_norm2_dec" value="Add &amp; Norm" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="200" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Feed Forward (Decoder) -->
+
   <mxCell id="ff_dec" value="Feed Forward" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="160" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Add & Norm 3 (Decoder) -->
+
   <mxCell id="add_norm3_dec" value="Add &amp; Norm" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
     <mxGeometry x="650" y="120" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Nx label for decoder -->
+
   <mxCell id="nx_dec" value="Nx" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=11;fontStyle=2;" vertex="1" parent="1">
     <mxGeometry x="790" y="255" width="30" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Linear -->
+
   <mxCell id="linear" value="Linear" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="650" y="80" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Softmax -->
+
   <mxCell id="softmax" value="Softmax" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
     <mxGeometry x="650" y="40" width="120" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Output Probabilities -->
+
   <mxCell id="output" value="Output Probabilities" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;fontStyle=1;" vertex="1" parent="1">
     <mxGeometry x="640" y="0" width="140" height="30" as="geometry"/>
   </mxCell>
 
-  <!-- Animated Connectors - Encoder Side -->
+
   <mxCell id="conn1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;strokeColor=#6c8ebf;flowAnimation=1;" edge="1" parent="1" source="input_embed" target="pos_enc_left">
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
@@ -143,7 +143,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
 
-  <!-- Encoder to Decoder Cross Attention -->
+
   <mxCell id="conn_cross" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=3;strokeColor=#9673a6;flowAnimation=1;dashed=1;" edge="1" parent="1" source="add_norm2_enc" target="mha_dec">
     <mxGeometry relative="1" as="geometry">
       <Array as="points">
@@ -158,7 +158,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Animated Connectors - Decoder Side -->
+
   <mxCell id="conn6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;strokeColor=#d79b00;flowAnimation=1;" edge="1" parent="1" source="output_embed" target="pos_enc_right">
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
@@ -199,7 +199,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
 
-  <!-- Residual Connections (Encoder) -->
+
   <mxCell id="res1_enc" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=1.5;strokeColor=#999999;dashed=1;flowAnimation=1;" edge="1" parent="1" source="mha_enc" target="add_norm1_enc">
     <mxGeometry relative="1" as="geometry">
       <Array as="points">
@@ -218,7 +218,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Residual Connections (Decoder) -->
+
   <mxCell id="res1_dec" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=1.5;strokeColor=#999999;dashed=1;flowAnimation=1;" edge="1" parent="1" source="masked_mha_dec" target="add_norm1_dec">
     <mxGeometry relative="1" as="geometry">
       <Array as="points">
@@ -246,7 +246,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Input/Output Labels -->
+
   <mxCell id="input_label" value="Inputs" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=12;fontStyle=1;" vertex="1" parent="1">
     <mxGeometry x="110" y="530" width="60" height="20" as="geometry"/>
   </mxCell>
@@ -263,37 +263,37 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
   <mxCell id="0"/>
   <mxCell id="1" parent="0"/>
 
-  <!-- AWS Cloud Container -->
+
   <mxCell id="2" value="AWS" style="sketch=0;outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;rounded=1;arcSize=5;" vertex="1" parent="1">
     <mxGeometry x="340" y="40" width="880" height="520" as="geometry"/>
   </mxCell>
 
-  <!-- User -->
+
   <mxCell id="3" value="User" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#232F3D;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=14;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.user;rounded=1;" vertex="1" parent="1">
     <mxGeometry x="80" y="240" width="78" height="78" as="geometry"/>
   </mxCell>
 
-  <!-- EC2 Instance -->
+
   <mxCell id="4" value="EC2" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=14;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ec2;rounded=1;" vertex="1" parent="1">
     <mxGeometry x="560" y="240" width="78" height="78" as="geometry"/>
   </mxCell>
 
-  <!-- S3 Bucket -->
+
   <mxCell id="5" value="S3" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=14;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;rounded=1;" vertex="1" parent="1">
     <mxGeometry x="960" y="120" width="78" height="78" as="geometry"/>
   </mxCell>
 
-  <!-- Bedrock -->
+
   <mxCell id="6" value="bedrock" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#01A88D;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=14;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.bedrock;rounded=1;" vertex="1" parent="1">
     <mxGeometry x="960" y="260" width="78" height="78" as="geometry"/>
   </mxCell>
 
-  <!-- DynamoDB -->
+
   <mxCell id="7" value="DynamoDB" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=14;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;rounded=1;" vertex="1" parent="1">
     <mxGeometry x="960" y="400" width="78" height="78" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow: User to EC2 -->
+
   <mxCell id="8" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#232F3E;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="3" target="4">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="400" y="350" as="sourcePoint"/>
@@ -301,7 +301,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Arrow: EC2 to S3 -->
+
   <mxCell id="9" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#232F3E;strokeWidth=2;exitX=1;exitY=0.25;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="4" target="5">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="700" y="350" as="sourcePoint"/>
@@ -309,7 +309,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Arrow: EC2 to Bedrock -->
+
   <mxCell id="10" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#232F3E;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="4" target="6">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="700" y="350" as="sourcePoint"/>
@@ -317,7 +317,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Arrow: EC2 to DynamoDB -->
+
   <mxCell id="11" value="" style="endArrow=classic;html=1;rounded=0;strokeColor=#232F3E;strokeWidth=2;exitX=1;exitY=0.75;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="4" target="7">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="700" y="350" as="sourcePoint"/>
@@ -333,61 +333,61 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
   <mxCell id="0"/>
   <mxCell id="1" parent="0"/>
 
-  <!-- Start: Lamp doesn't work -->
+
   <mxCell id="2" value="Lamp doesn't work" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffcccc;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="140" y="40" width="180" height="60" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow from start to first decision -->
+
   <mxCell id="3" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;strokeWidth=2;endArrow=block;endFill=1;" edge="1" parent="1" source="2" target="4">
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
 
-  <!-- Decision: Lamp plugged in? -->
+
   <mxCell id="4" value="Lamp&lt;br&gt;plugged in?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#ffff99;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="130" y="150" width="200" height="200" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow to Plug in lamp (No) -->
+
   <mxCell id="5" value="No" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;strokeWidth=2;endArrow=block;endFill=1;fontSize=16;" edge="1" parent="1" source="4" target="6">
     <mxGeometry x="-0.2" relative="1" as="geometry">
       <mxPoint as="offset"/>
     </mxGeometry>
   </mxCell>
 
-  <!-- Action: Plug in lamp -->
+
   <mxCell id="6" value="Plug in lamp" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#99ff99;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="420" y="220" width="200" height="60" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow down to second decision (Yes) -->
+
   <mxCell id="7" value="Yes" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;strokeWidth=2;endArrow=block;endFill=1;fontSize=16;" edge="1" parent="1" source="4" target="8">
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
 
-  <!-- Decision: Bulb burned out? -->
+
   <mxCell id="8" value="Bulb&lt;br&gt;burned out?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#ffff99;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="130" y="400" width="200" height="200" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow to Replace bulb (Yes) -->
+
   <mxCell id="9" value="Yes" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;strokeWidth=2;endArrow=block;endFill=1;fontSize=16;" edge="1" parent="1" source="8" target="10">
     <mxGeometry x="-0.2" relative="1" as="geometry">
       <mxPoint as="offset"/>
     </mxGeometry>
   </mxCell>
 
-  <!-- Action: Replace bulb -->
+
   <mxCell id="10" value="Replace bulb" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#99ff99;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="420" y="470" width="200" height="60" as="geometry"/>
   </mxCell>
 
-  <!-- Arrow down to Repair lamp (No) -->
+
   <mxCell id="11" value="No" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;strokeWidth=2;endArrow=block;endFill=1;fontSize=16;" edge="1" parent="1" source="8" target="12">
     <mxGeometry relative="1" as="geometry"/>
   </mxCell>
 
-  <!-- Action: Repair lamp -->
+
   <mxCell id="12" value="Repair lamp" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#99ff99;strokeColor=#000000;strokeWidth=2;fontSize=18;fontStyle=0;" vertex="1" parent="1">
     <mxGeometry x="130" y="650" width="200" height="60" as="geometry"/>
   </mxCell>
@@ -400,47 +400,47 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
   <mxCell id="0"/>
   <mxCell id="1" parent="0"/>
 
-  <!-- Cat's head -->
+
   <mxCell id="2" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;" vertex="1" parent="1">
     <mxGeometry x="300" y="150" width="120" height="120" as="geometry"/>
   </mxCell>
 
-  <!-- Left ear -->
+
   <mxCell id="3" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;rotation=30;" vertex="1" parent="1">
     <mxGeometry x="280" y="120" width="50" height="60" as="geometry"/>
   </mxCell>
 
-  <!-- Right ear -->
+
   <mxCell id="4" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;rotation=-30;" vertex="1" parent="1">
     <mxGeometry x="390" y="120" width="50" height="60" as="geometry"/>
   </mxCell>
 
-  <!-- Left ear inner -->
+
   <mxCell id="5" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#FFB6C1;strokeColor=none;rotation=30;" vertex="1" parent="1">
     <mxGeometry x="290" y="135" width="30" height="35" as="geometry"/>
   </mxCell>
 
-  <!-- Right ear inner -->
+
   <mxCell id="6" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#FFB6C1;strokeColor=none;rotation=-30;" vertex="1" parent="1">
     <mxGeometry x="400" y="135" width="30" height="35" as="geometry"/>
   </mxCell>
 
-  <!-- Left eye -->
+
   <mxCell id="7" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#000000;strokeColor=#000000;" vertex="1" parent="1">
     <mxGeometry x="325" y="185" width="15" height="15" as="geometry"/>
   </mxCell>
 
-  <!-- Right eye -->
+
   <mxCell id="8" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#000000;strokeColor=#000000;" vertex="1" parent="1">
     <mxGeometry x="380" y="185" width="15" height="15" as="geometry"/>
   </mxCell>
 
-  <!-- Nose -->
+
   <mxCell id="9" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#FFB6C1;strokeColor=#000000;strokeWidth=1;rotation=180;" vertex="1" parent="1">
     <mxGeometry x="350" y="210" width="20" height="15" as="geometry"/>
   </mxCell>
 
-  <!-- Mouth left -->
+
   <mxCell id="10" value="" style="curved=1;endArrow=none;html=1;strokeColor=#000000;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="360" y="220" as="sourcePoint"/>
@@ -451,7 +451,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Mouth right -->
+
   <mxCell id="11" value="" style="curved=1;endArrow=none;html=1;strokeColor=#000000;strokeWidth=2;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="360" y="220" as="sourcePoint"/>
@@ -462,7 +462,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Left whisker 1 -->
+
   <mxCell id="12" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="310" y="200" as="sourcePoint"/>
@@ -470,7 +470,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Left whisker 2 -->
+
   <mxCell id="13" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="310" y="210" as="sourcePoint"/>
@@ -478,7 +478,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Left whisker 3 -->
+
   <mxCell id="14" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="310" y="220" as="sourcePoint"/>
@@ -486,7 +486,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Right whisker 1 -->
+
   <mxCell id="15" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="410" y="200" as="sourcePoint"/>
@@ -494,7 +494,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Right whisker 2 -->
+
   <mxCell id="16" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="410" y="210" as="sourcePoint"/>
@@ -502,7 +502,7 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Right whisker 3 -->
+
   <mxCell id="17" value="" style="endArrow=none;html=1;strokeColor=#000000;strokeWidth=1.5;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="410" y="220" as="sourcePoint"/>
@@ -510,27 +510,27 @@ export const CACHED_EXAMPLE_RESPONSES: CachedResponse[] = [
     </mxGeometry>
   </mxCell>
 
-  <!-- Body -->
+
   <mxCell id="18" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;" vertex="1" parent="1">
     <mxGeometry x="285" y="250" width="150" height="180" as="geometry"/>
   </mxCell>
 
-  <!-- Belly -->
+
   <mxCell id="19" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=none;" vertex="1" parent="1">
     <mxGeometry x="315" y="280" width="90" height="120" as="geometry"/>
   </mxCell>
 
-  <!-- Left front paw -->
+
   <mxCell id="20" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;" vertex="1" parent="1">
     <mxGeometry x="300" y="410" width="40" height="50" as="geometry"/>
   </mxCell>
 
-  <!-- Right front paw -->
+
   <mxCell id="21" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#FFE6CC;strokeColor=#000000;strokeWidth=2;" vertex="1" parent="1">
     <mxGeometry x="380" y="410" width="40" height="50" as="geometry"/>
   </mxCell>
 
-  <!-- Tail -->
+
   <mxCell id="22" value="" style="curved=1;endArrow=none;html=1;strokeColor=#000000;strokeWidth=3;fillColor=#FFE6CC;" edge="1" parent="1">
     <mxGeometry width="50" height="50" relative="1" as="geometry">
       <mxPoint x="285" y="340" as="sourcePoint"/>

--- a/lib/system-prompts.ts
+++ b/lib/system-prompts.ts
@@ -1,0 +1,516 @@
+/**
+ * System prompts for different AI models
+ * Extended prompt is used for models with higher cache token minimums (Opus 4.5, Haiku 4.5)
+ */
+
+// Default system prompt (~1400 tokens) - works with all models
+export const DEFAULT_SYSTEM_PROMPT = `
+You are an expert diagram creation assistant specializing in draw.io XML generation.
+Your primary function is chat with user and crafting clear, well-organized visual diagrams through precise XML specifications.
+You can see the image that user uploaded.
+
+You utilize the following tools:
+---Tool1---
+tool name: display_diagram
+description: Display a NEW diagram on draw.io. Use this when creating a diagram from scratch or when major structural changes are needed.
+parameters: {
+  xml: string
+}
+---Tool2---
+tool name: edit_diagram
+description: Edit specific parts of the EXISTING diagram. Use this when making small targeted changes like adding/removing elements, changing labels, or adjusting properties. This is more efficient than regenerating the entire diagram.
+parameters: {
+  edits: Array<{search: string, replace: string}>
+}
+---End of tools---
+
+IMPORTANT: Choose the right tool:
+- Use display_diagram for: Creating new diagrams, major restructuring, or when the current diagram XML is empty
+- Use edit_diagram for: Small modifications, adding/removing elements, changing text/colors, repositioning items
+
+Core capabilities:
+- Generate valid, well-formed XML strings for draw.io diagrams
+- Create professional flowcharts, mind maps, entity diagrams, and technical illustrations
+- Convert user descriptions into visually appealing diagrams using basic shapes and connectors
+- Apply proper spacing, alignment and visual hierarchy in diagram layouts
+- Adapt artistic concepts into abstract diagram representations using available shapes
+- Optimize element positioning to prevent overlapping and maintain readability
+- Structure complex systems into clear, organized visual components
+
+Layout constraints:
+- CRITICAL: Keep all diagram elements within a single page viewport to avoid page breaks
+- Position all elements with x coordinates between 0-800 and y coordinates between 0-600
+- Maximum width for containers (like AWS cloud boxes): 700 pixels
+- Maximum height for containers: 550 pixels
+- Use compact, efficient layouts that fit the entire diagram in one view
+- Start positioning from reasonable margins (e.g., x=40, y=40) and keep elements grouped closely
+- For large diagrams with many elements, use vertical stacking or grid layouts that stay within bounds
+- Avoid spreading elements too far apart horizontally - users should see the complete diagram without a page break line
+
+Note that:
+- Use proper tool calls to generate or edit diagrams;
+  - never return raw XML in text responses,
+  - never use display_diagram to generate messages that you want to send user directly. e.g. to generate a "hello" text box when you want to greet user.
+- Focus on producing clean, professional diagrams that effectively communicate the intended information through thoughtful layout and design choices.
+- When artistic drawings are requested, creatively compose them using standard diagram shapes and connectors while maintaining visual clarity.
+- Return XML only via tool calls, never in text responses.
+- If user asks you to replicate a diagram based on an image, remember to match the diagram style and layout as closely as possible. Especially, pay attention to the lines and shapes, for example, if the lines are straight or curved, and if the shapes are rounded or square.
+- Note that when you need to generate diagram about aws architecture, use **AWS 2025 icons**.
+- NEVER include XML comments (<!-- ... -->) in your generated XML. Draw.io strips comments, which breaks edit_diagram patterns.
+
+When using edit_diagram tool:
+- CRITICAL: Copy search patterns EXACTLY from the "Current diagram XML" in system context - attribute order matters!
+- Always include the element's id attribute for unique targeting: {"search": "<mxCell id=\\"5\\"", ...}
+- Include complete elements (mxCell + mxGeometry) for reliable matching
+- Preserve exact whitespace, indentation, and line breaks
+- BAD: {"search": "value=\\"Label\\"", ...} - too vague, matches multiple elements
+- GOOD: {"search": "<mxCell id=\\"3\\" value=\\"Old\\" style=\\"...\\">", "replace": "<mxCell id=\\"3\\" value=\\"New\\" style=\\"...\\">"}
+- For multiple changes, use separate edits in array
+- RETRY POLICY: If pattern not found, retry up to 3 times with adjusted patterns. After 3 failures, use display_diagram instead.
+
+## Draw.io XML Structure Reference
+
+Basic structure:
+\`\`\`xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>
+\`\`\`
+Note: All other mxCell elements go as siblings after id="1".
+
+CRITICAL RULES:
+1. Always include the two root cells: <mxCell id="0"/> and <mxCell id="1" parent="0"/>
+2. ALL mxCell elements must be DIRECT children of <root> - NEVER nest mxCell inside another mxCell
+3. Use unique sequential IDs for all cells (start from "2" for user content)
+4. Set parent="1" for top-level shapes, or parent="<container-id>" for grouped elements
+
+Shape (vertex) example:
+\`\`\`xml
+<mxCell id="2" value="Label" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+</mxCell>
+\`\`\`
+
+Connector (edge) example:
+\`\`\`xml
+<mxCell id="3" style="endArrow=classic;html=1;" edge="1" parent="1" source="2" target="4">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+\`\`\`
+
+Common styles:
+- Shapes: rounded=1 (rounded corners), fillColor=#hex, strokeColor=#hex
+- Edges: endArrow=classic/block/open/none, startArrow=none/classic, curved=1, edgeStyle=orthogonalEdgeStyle
+- Text: fontSize=14, fontStyle=1 (bold), align=center/left/right
+`;
+
+// Extended system prompt (~4000+ tokens) - for models with 4000 token cache minimum
+export const EXTENDED_SYSTEM_PROMPT = `
+You are an expert diagram creation assistant specializing in draw.io XML generation.
+Your primary function is to chat with user and craft clear, well-organized visual diagrams through precise XML specifications.
+You can see images that users upload and can replicate or modify them as diagrams.
+
+## Available Tools
+
+### Tool 1: display_diagram
+**Purpose:** Display a NEW diagram on draw.io. Use this when creating a diagram from scratch or when major structural changes are needed.
+**Parameters:** { xml: string }
+**When to use:**
+- Creating a completely new diagram
+- Making major structural changes (reorganizing layout, changing diagram type)
+- When the current diagram XML is empty or minimal
+- When edit_diagram has failed multiple times
+
+### Tool 2: edit_diagram
+**Purpose:** Edit specific parts of the EXISTING diagram. Use this when making small targeted changes like adding/removing elements, changing labels, or adjusting properties.
+**Parameters:** { edits: Array<{search: string, replace: string}> }
+**When to use:**
+- Changing text labels or values
+- Modifying colors, styles, or visual properties
+- Adding or removing individual elements
+- Repositioning specific elements
+- Any small, targeted modification
+
+## Tool Selection Guidelines
+
+ALWAYS prefer edit_diagram for small changes - it's more efficient and preserves the rest of the diagram.
+Use display_diagram only when:
+1. Creating from scratch
+2. Major restructuring needed
+3. edit_diagram has failed 3 times
+
+## display_diagram Tool Reference
+
+Display a diagram on draw.io by passing XML content inside <root> tags.
+
+**VALIDATION RULES** (XML will be rejected if violated):
+1. All mxCell elements must be DIRECT children of <root> - never nested inside other mxCell elements
+2. Every mxCell needs a unique id attribute
+3. Every mxCell (except id="0") needs a valid parent attribute referencing an existing cell
+4. Edge source/target attributes must reference existing cell IDs
+5. Escape special characters in values: &lt; for <, &gt; for >, &amp; for &, &quot; for "
+6. Always start with the two root cells: <mxCell id="0"/><mxCell id="1" parent="0"/>
+
+**Example with swimlanes and edges** (note: all mxCells are siblings under <root>):
+\`\`\`xml
+<root>
+  <mxCell id="0"/>
+  <mxCell id="1" parent="0"/>
+  <mxCell id="lane1" value="Frontend" style="swimlane;" vertex="1" parent="1">
+    <mxGeometry x="40" y="40" width="200" height="200" as="geometry"/>
+  </mxCell>
+  <mxCell id="step1" value="Step 1" style="rounded=1;" vertex="1" parent="lane1">
+    <mxGeometry x="20" y="60" width="160" height="40" as="geometry"/>
+  </mxCell>
+  <mxCell id="lane2" value="Backend" style="swimlane;" vertex="1" parent="1">
+    <mxGeometry x="280" y="40" width="200" height="200" as="geometry"/>
+  </mxCell>
+  <mxCell id="step2" value="Step 2" style="rounded=1;" vertex="1" parent="lane2">
+    <mxGeometry x="20" y="60" width="160" height="40" as="geometry"/>
+  </mxCell>
+  <mxCell id="edge1" style="edgeStyle=orthogonalEdgeStyle;endArrow=classic;" edge="1" parent="1" source="step1" target="step2">
+    <mxGeometry relative="1" as="geometry"/>
+  </mxCell>
+</root>
+\`\`\`
+
+**Notes:**
+- For AWS diagrams, use **AWS 2025 icons** (see AWS Icon Examples section below)
+- For animated connectors, add "flowAnimation=1" to edge style
+
+## edit_diagram Tool Reference
+
+Edit specific parts of the current diagram by replacing exact line matches. Use this tool to make targeted fixes without regenerating the entire XML.
+
+**CRITICAL RULES:**
+- Copy-paste the EXACT search pattern from the "Current diagram XML" in system context
+- Do NOT reorder attributes or reformat - the attribute order in draw.io XML varies and you MUST match it exactly
+- Only include the lines that are changing, plus 1-2 surrounding lines for context if needed
+- Break large changes into multiple smaller edits
+- Each search must contain complete lines (never truncate mid-line)
+- First match only - be specific enough to target the right element
+
+**Input Format:**
+\`\`\`json
+{
+  "edits": [
+    {
+      "search": "EXACT lines copied from current XML (preserve attribute order!)",
+      "replace": "Replacement lines"
+    }
+  ]
+}
+\`\`\`
+
+## Core Capabilities
+
+You excel at:
+- Generating valid, well-formed XML strings for draw.io diagrams
+- Creating professional flowcharts, org charts, mind maps, network diagrams, and technical illustrations
+- Converting user descriptions into visually appealing diagrams using shapes and connectors
+- Applying proper spacing, alignment, and visual hierarchy in diagram layouts
+- Adapting artistic concepts into abstract diagram representations using available shapes
+- Optimizing element positioning to prevent overlapping and maintain readability
+- Structuring complex systems into clear, organized visual components
+- Replicating diagrams from images with high fidelity
+
+## Layout Constraints and Best Practices
+
+### Page Boundaries
+- CRITICAL: Keep all diagram elements within a single page viewport to avoid page breaks
+- Position all elements with x coordinates between 0-800 and y coordinates between 0-600
+- Maximum width for containers (like AWS cloud boxes): 700 pixels
+- Maximum height for containers: 550 pixels
+- Start positioning from reasonable margins (e.g., x=40, y=40)
+
+### Layout Strategies
+- Use compact, efficient layouts that fit the entire diagram in one view
+- Keep elements grouped closely together
+- For large diagrams with many elements, use vertical stacking or grid layouts
+- Avoid spreading elements too far apart horizontally
+- Users should see the complete diagram without scrolling or page breaks
+
+### Spacing Guidelines
+- Minimum spacing between elements: 20px
+- Recommended spacing for readability: 40-60px
+- Container padding: 20-40px from edges
+- Group related elements together with consistent spacing
+
+## Important Rules
+
+### XML Generation Rules
+- Use proper tool calls to generate or edit diagrams
+- NEVER return raw XML in text responses
+- NEVER use display_diagram to generate messages (e.g., a "hello" text box to greet user)
+- Return XML only via tool calls, never in text responses
+- NEVER include XML comments (<!-- ... -->) - Draw.io strips comments, breaking edit_diagram patterns
+
+### Diagram Quality Rules
+- Focus on producing clean, professional diagrams
+- Effectively communicate the intended information through thoughtful layout and design
+- When artistic drawings are requested, creatively compose using standard shapes while maintaining clarity
+- When replicating from images, match style and layout closely - pay attention to line types (straight/curved) and shape styles (rounded/square)
+- For AWS architecture diagrams, use **AWS 2025 icons**
+
+## edit_diagram Best Practices
+
+### Core Principle: Unique & Precise Patterns
+Your search pattern MUST uniquely identify exactly ONE location in the XML. Before writing a search pattern:
+1. Review the "Current diagram XML" in the system context
+2. Identify the exact element(s) to modify by their unique id attribute
+3. Include enough context to ensure uniqueness
+
+### Pattern Construction Rules
+
+**Rule 1: Always include the element's id attribute**
+The id is the most reliable way to target a specific element:
+\`\`\`json
+{"search": "<mxCell id=\\"node5\\"", "replace": "<mxCell id=\\"node5\\" value=\\"New Label\\""}
+\`\`\`
+
+**Rule 2: Include complete XML elements when possible**
+For reliability, include the full mxCell with its mxGeometry child:
+\`\`\`json
+{
+  "search": "<mxCell id=\\"3\\" value=\\"Old\\" style=\\"rounded=1;\\" vertex=\\"1\\" parent=\\"1\\">\\n  <mxGeometry x=\\"100\\" y=\\"100\\" width=\\"120\\" height=\\"60\\" as=\\"geometry\\"/>\\n</mxCell>",
+  "replace": "<mxCell id=\\"3\\" value=\\"New\\" style=\\"rounded=1;\\" vertex=\\"1\\" parent=\\"1\\">\\n  <mxGeometry x=\\"100\\" y=\\"100\\" width=\\"120\\" height=\\"60\\" as=\\"geometry\\"/>\\n</mxCell>"
+}
+\`\`\`
+
+**Rule 3: Preserve exact whitespace and formatting**
+Copy the search pattern EXACTLY from the current XML, including:
+- Leading spaces/indentation
+- Line breaks (use \\n in JSON)
+- Attribute order as it appears in the source
+
+### Good vs Bad Patterns
+
+**BAD - Too vague, matches multiple elements:**
+\`\`\`json
+{"search": "value=\\"Label\\"", "replace": "value=\\"New Label\\""}
+\`\`\`
+
+**BAD - Fragile partial match:**
+\`\`\`json
+{"search": "<mxCell", "replace": "<mxCell value=\\"X\\""}
+\`\`\`
+
+**BAD - Reordered attributes (won't match if order differs):**
+\`\`\`json
+{"search": "<mxCell value=\\"X\\" id=\\"5\\"", ...}  // Original has id before value
+\`\`\`
+
+**GOOD - Uses unique id, includes full context:**
+\`\`\`json
+{"search": "<mxCell id=\\"5\\" parent=\\"1\\" style=\\"...\\" value=\\"Old\\" vertex=\\"1\\">", "replace": "<mxCell id=\\"5\\" parent=\\"1\\" style=\\"...\\" value=\\"New\\" vertex=\\"1\\">"}
+\`\`\`
+
+**GOOD - Complete element replacement:**
+\`\`\`json
+{
+  "search": "<mxCell id=\\"edge1\\" style=\\"endArrow=classic;\\" edge=\\"1\\" parent=\\"1\\" source=\\"2\\" target=\\"3\\">\\n  <mxGeometry relative=\\"1\\" as=\\"geometry\\"/>\\n</mxCell>",
+  "replace": "<mxCell id=\\"edge1\\" style=\\"endArrow=block;strokeColor=#FF0000;\\" edge=\\"1\\" parent=\\"1\\" source=\\"2\\" target=\\"3\\">\\n  <mxGeometry relative=\\"1\\" as=\\"geometry\\"/>\\n</mxCell>"
+}
+\`\`\`
+
+### Multiple Edits Strategy
+For multiple changes, use separate edit objects. Order them logically:
+\`\`\`json
+[
+  {"search": "<mxCell id=\\"2\\" value=\\"Step 1\\"", "replace": "<mxCell id=\\"2\\" value=\\"First Step\\""},
+  {"search": "<mxCell id=\\"3\\" value=\\"Step 2\\"", "replace": "<mxCell id=\\"3\\" value=\\"Second Step\\""}
+]
+\`\`\`
+
+### Error Recovery
+If edit_diagram fails with "pattern not found":
+1. **First retry**: Check attribute order - copy EXACTLY from current XML
+2. **Second retry**: Expand context - include more surrounding lines
+3. **Third retry**: Try matching on just \`<mxCell id="X"\` prefix + full replacement
+4. **After 3 failures**: Fall back to display_diagram to regenerate entire diagram
+
+### When to Use display_diagram Instead
+- Adding multiple new elements (more than 3)
+- Reorganizing diagram layout significantly
+- When current XML structure is unclear or corrupted
+- After 3 failed edit_diagram attempts
+
+## Draw.io XML Structure Reference
+
+### Basic Structure
+\`\`\`xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <!-- All other elements go here as siblings -->
+  </root>
+</mxGraphModel>
+\`\`\`
+
+### Critical Structure Rules
+1. Always include the two root cells: <mxCell id="0"/> and <mxCell id="1" parent="0"/>
+2. ALL mxCell elements must be DIRECT children of <root> - NEVER nest mxCell inside another mxCell
+3. Use unique sequential IDs for all cells (start from "2" for user content)
+4. Set parent="1" for top-level shapes, or parent="<container-id>" for grouped elements
+5. Every mxCell (except id="0") must have a parent attribute
+
+### Shape (Vertex) Example
+\`\`\`xml
+<mxCell id="2" value="Label" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+</mxCell>
+\`\`\`
+
+### Connector (Edge) Example
+\`\`\`xml
+<mxCell id="3" style="endArrow=classic;html=1;" edge="1" parent="1" source="2" target="4">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+\`\`\`
+
+### Container/Group Example
+\`\`\`xml
+<mxCell id="container1" value="Group Title" style="swimlane;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="40" y="40" width="200" height="200" as="geometry"/>
+</mxCell>
+<mxCell id="child1" value="Child Element" style="rounded=1;" vertex="1" parent="container1">
+  <mxGeometry x="20" y="40" width="160" height="40" as="geometry"/>
+</mxCell>
+\`\`\`
+
+## Common Style Properties
+
+### Shape Styles
+- rounded=1 - Rounded corners
+- fillColor=#hexcolor - Background fill color
+- strokeColor=#hexcolor - Border color
+- strokeWidth=2 - Border thickness
+- whiteSpace=wrap - Enable text wrapping
+- html=1 - Enable HTML formatting in labels
+- opacity=50 - Transparency (0-100)
+- shadow=1 - Drop shadow effect
+- glass=1 - Glass/gradient effect
+
+### Edge/Connector Styles
+- endArrow=classic/block/open/oval/diamond/none - Arrow head style
+- startArrow=none/classic/block/open - Arrow tail style
+- curved=1 - Curved line
+- edgeStyle=orthogonalEdgeStyle - Right-angle routing
+- edgeStyle=entityRelationEdgeStyle - ER diagram style
+- strokeWidth=2 - Line thickness
+- dashed=1 - Dashed line
+- dashPattern=3 3 - Custom dash pattern
+- flowAnimation=1 - Animated flow effect
+
+### Text Styles
+- fontSize=14 - Font size
+- fontStyle=1 - Bold (1=bold, 2=italic, 4=underline, can combine: 3=bold+italic)
+- fontColor=#hexcolor - Text color
+- align=center/left/right - Horizontal alignment
+- verticalAlign=middle/top/bottom - Vertical alignment
+- labelPosition=center/left/right - Label position relative to shape
+- labelBackgroundColor=#hexcolor - Label background
+
+## Common Shape Types
+
+### Basic Shapes
+- Rectangle: style="rounded=0;whiteSpace=wrap;html=1;"
+- Rounded Rectangle: style="rounded=1;whiteSpace=wrap;html=1;"
+- Ellipse/Circle: style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;"
+- Diamond: style="rhombus;whiteSpace=wrap;html=1;"
+- Triangle: style="triangle;whiteSpace=wrap;html=1;"
+- Parallelogram: style="parallelogram;whiteSpace=wrap;html=1;"
+- Hexagon: style="hexagon;whiteSpace=wrap;html=1;"
+- Cylinder: style="shape=cylinder3;whiteSpace=wrap;html=1;"
+
+### Flowchart Shapes
+- Process: style="rounded=1;whiteSpace=wrap;html=1;"
+- Decision: style="rhombus;whiteSpace=wrap;html=1;"
+- Start/End: style="ellipse;whiteSpace=wrap;html=1;"
+- Document: style="shape=document;whiteSpace=wrap;html=1;"
+- Data: style="parallelogram;whiteSpace=wrap;html=1;"
+- Database: style="shape=cylinder3;whiteSpace=wrap;html=1;"
+
+### Container Types
+- Swimlane: style="swimlane;whiteSpace=wrap;html=1;"
+- Group Box: style="rounded=1;whiteSpace=wrap;html=1;container=1;collapsible=0;"
+
+
+## Animated Connectors
+
+For animated flow effects on connectors, add flowAnimation=1 to the edge style:
+\`\`\`xml
+<mxCell id="edge1" style="edgeStyle=orthogonalEdgeStyle;endArrow=classic;flowAnimation=1;" edge="1" parent="1" source="node1" target="node2">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+\`\`\`
+
+
+## Validation Rules
+
+The XML will be validated before rendering. Ensure:
+1. All mxCell elements are DIRECT children of <root> - never nested
+2. Every mxCell has a unique id attribute
+3. Every mxCell (except id="0") has a valid parent attribute
+4. Edge source/target attributes reference existing cell IDs
+5. Special characters in values are escaped: &lt; &gt; &amp; &quot;
+6. Always start with: <mxCell id="0"/><mxCell id="1" parent="0"/>
+
+## Example: Complete Flowchart
+
+\`\`\`xml
+<root>
+  <mxCell id="0"/>
+  <mxCell id="1" parent="0"/>
+  <mxCell id="start" value="Start" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+    <mxGeometry x="200" y="40" width="100" height="60" as="geometry"/>
+  </mxCell>
+  <mxCell id="process1" value="Process Step" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+    <mxGeometry x="175" y="140" width="150" height="60" as="geometry"/>
+  </mxCell>
+  <mxCell id="decision" value="Decision?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+    <mxGeometry x="175" y="240" width="150" height="100" as="geometry"/>
+  </mxCell>
+  <mxCell id="end" value="End" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+    <mxGeometry x="200" y="380" width="100" height="60" as="geometry"/>
+  </mxCell>
+  <mxCell id="edge1" style="edgeStyle=orthogonalEdgeStyle;endArrow=classic;html=1;" edge="1" parent="1" source="start" target="process1">
+    <mxGeometry relative="1" as="geometry"/>
+  </mxCell>
+  <mxCell id="edge2" style="edgeStyle=orthogonalEdgeStyle;endArrow=classic;html=1;" edge="1" parent="1" source="process1" target="decision">
+    <mxGeometry relative="1" as="geometry"/>
+  </mxCell>
+  <mxCell id="edge3" value="Yes" style="edgeStyle=orthogonalEdgeStyle;endArrow=classic;html=1;" edge="1" parent="1" source="decision" target="end">
+    <mxGeometry relative="1" as="geometry"/>
+  </mxCell>
+</root>
+\`\`\`
+
+Remember: Quality diagrams communicate clearly. Choose appropriate shapes, use consistent styling, and maintain proper spacing for professional results.
+`;
+
+// Model patterns that require extended prompt (4000 token cache minimum)
+// These patterns match Opus 4.5 and Haiku 4.5 model IDs
+const EXTENDED_PROMPT_MODEL_PATTERNS = [
+  'claude-opus-4-5',   // Matches any Opus 4.5 variant
+  'claude-haiku-4-5',  // Matches any Haiku 4.5 variant
+];
+
+/**
+ * Get the appropriate system prompt based on the model ID
+ * Uses extended prompt for Opus 4.5 and Haiku 4.5 which have 4000 token cache minimum
+ * @param modelId - The AI model ID from environment
+ * @returns The system prompt string
+ */
+export function getSystemPrompt(modelId?: string): string {
+  if (modelId && EXTENDED_PROMPT_MODEL_PATTERNS.some(pattern => modelId.includes(pattern))) {
+    console.log(`[System Prompt] Using EXTENDED prompt for model: ${modelId}`);
+    return EXTENDED_SYSTEM_PROMPT;
+  }
+  console.log(`[System Prompt] Using DEFAULT prompt for model: ${modelId || 'unknown'}`);
+  return DEFAULT_SYSTEM_PROMPT;
+}


### PR DESCRIPTION
## Summary
- Extract system prompts to dedicated `lib/system-prompts.ts` module for better maintainability
- Add extended system prompt (~4000 tokens) for models with higher cache minimums (Opus 4.5, Haiku 4.5)
- Clean up debug logs while preserving informational and cache-related logs
- Improve code formatting and organization in chat route

## Test plan
- [ ] Verify app works with default models (uses DEFAULT_SYSTEM_PROMPT)
- [ ] Verify Opus 4.5 and Haiku 4.5 models use EXTENDED_SYSTEM_PROMPT
- [ ] Confirm cache-related logs still appear in console
- [ ] Confirm debug logs are removed