### PR TITLE
fix: clear files when clicking text-only examples

### DIFF
--- a/components/chat-example-panel.tsx
+++ b/components/chat-example-panel.tsx
@@ -90,7 +90,10 @@ export default function ExamplePanel({
                         icon={<Zap className="w-4 h-4 text-primary" />}
                         title="Animated Diagram"
                         description="Draw a transformer architecture with animated connectors"
-                        onClick={() => setInput("Give me a **animated connector** diagram of transformer's architecture")}
+                        onClick={() => {
+                            setInput("Give me a **animated connector** diagram of transformer's architecture")
+                            setFiles([])
+                        }}
                     />
 
                     <ExampleCard
@@ -111,7 +114,10 @@ export default function ExamplePanel({
                         icon={<Palette className="w-4 h-4 text-primary" />}
                         title="Creative Drawing"
                         description="Draw something fun and creative"
-                        onClick={() => setInput("Draw a cat for me")}
+                        onClick={() => {
+                            setInput("Draw a cat for me")
+                            setFiles([])
+                        }}
                     />
                 </div>
 


### PR DESCRIPTION
### Problem
When clicking on the first example card (Animated Diagram) or the fourth example card (Creative Drawing), the file list was not being cleared. This caused previously uploaded images from the second or third example cards (AWS Architecture or Replicate Flowchart) to incorrectly carry over to text-only examples.

### Solution
Added `setFiles([])` call to the `onClick` handlers of both text-only example cards to ensure the file list is cleared when setting text-only inputs.