### PR TITLE
refactor: replace deprecated addToolResult with addToolOutput

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -64,7 +64,7 @@ export default function ChatPanel({
     // Generate a unique session ID for Langfuse tracing
     const [sessionId, setSessionId] = useState(() => `session-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
 
-    const { messages, sendMessage, addToolResult, status, error, setMessages } =
+    const { messages, sendMessage, addToolOutput, status, error, setMessages } =
         useChat({
             transport: new DefaultChatTransport({
                 api: "/api/chat",
@@ -76,13 +76,13 @@ export default function ChatPanel({
                     const validationError = validateMxCellStructure(xml);
 
                     if (validationError) {
-                        addToolResult({
+                        addToolOutput({
                             tool: "display_diagram",
                             toolCallId: toolCall.toolCallId,
                             output: validationError,
                         });
                     } else {
-                        addToolResult({
+                        addToolOutput({
                             tool: "display_diagram",
                             toolCallId: toolCall.toolCallId,
                             output: "Successfully displayed the diagram.",
@@ -103,7 +103,7 @@ export default function ChatPanel({
 
                         onDisplayChart(editedXml);
 
-                        addToolResult({
+                        addToolOutput({
                             tool: "edit_diagram",
                             toolCallId: toolCall.toolCallId,
                             output: `Successfully applied ${edits.length} edit(s) to the diagram.`,
@@ -116,7 +116,7 @@ export default function ChatPanel({
                                 ? error.message
                                 : String(error);
 
-                        addToolResult({
+                        addToolOutput({
                             tool: "edit_diagram",
                             toolCallId: toolCall.toolCallId,
                             output: `Edit failed: ${errorMessage}


### PR DESCRIPTION
### Changes
Replaced the deprecated `addToolResult` method with the new `addToolOutput` method from `ai`.

### Reason
The `addToolResult` API has been marked as deprecated. This update ensures compatibility with future versions of the AI SDK and follows the recommended API usage.