### PR TITLE
fix: enable UI retry when Bedrock returns early 503 error

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -29,6 +29,7 @@ interface ChatInputProps {
     onFileChange?: (files: File[]) => void;
     showHistory?: boolean;
     onToggleHistory?: (show: boolean) => void;
+    error?: Error | null;
 }
 
 export function ChatInput({
@@ -41,6 +42,7 @@ export function ChatInput({
     onFileChange = () => {},
     showHistory = false,
     onToggleHistory = () => {},
+    error = null,
 }: ChatInputProps) {
     const { diagramHistory, saveDiagramToFile } = useDiagram();
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -49,7 +51,8 @@ export function ChatInput({
     const [showClearDialog, setShowClearDialog] = useState(false);
     const [showSaveDialog, setShowSaveDialog] = useState(false);
 
-    const isDisabled = status === "streaming" || status === "submitted";
+    // Allow retry when there's an error (even if status is still "streaming" or "submitted")
+    const isDisabled = (status === "streaming" || status === "submitted") && !error;
 
     useEffect(() => {
         console.log('[ChatInput] Status changed to:', status, '| Input disabled:', isDisabled);

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -164,7 +164,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
     const lastMessagePartsRef = useRef(0);
 
     useEffect(() => {
-        // Clear streaming error and reset refs when status changes to ready
+        // Clear streaming error when status changes to ready
         if (status === "ready") {
             setStreamingError(null);
             lastMessageCountRef.current = 0;
@@ -498,6 +498,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     onFileChange={handleFileChange}
                     showHistory={showHistory}
                     onToggleHistory={setShowHistory}
+                    error={error || streamingError}
                 />
             </footer>
         </div>


### PR DESCRIPTION
## Summary

- Add error prop to ChatInput to detect error state
- Update isDisabled logic to allow retry when there's an error
- Pass combined error (SDK error + streamingError) to ChatInput

When Bedrock returns 503 ServiceUnavailableException before streaming starts, AI SDK's onError fires but status may not transition to "ready". This fix ensures the input is re-enabled when an error occurs, allowing users to retry their request.

## Changes

- `components/chat-input.tsx`: Added `error` prop, updated `isDisabled` to `(status === "streaming" || status === "submitted") && !error`
- `components/chat-panel.tsx`: Pass `error={error || streamingError}` to ChatInput