### PR TITLE
fix: use console.log for XML validation during streaming

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -115,7 +115,7 @@ export function ChatMessageDisplay({
                     previousXML.current = convertedXml;
                     onDisplayChart(replacedXML);
                 } else {
-                    console.error("[ChatMessageDisplay] XML validation failed:", validationError);
+                    console.log("[ChatMessageDisplay] XML validation failed:", validationError);
                 }
             }
         },


### PR DESCRIPTION
## Summary

- Changed `console.error` to `console.log` for XML validation failures during streaming
- Prevents Next.js error overlay from appearing during streaming when XML is incomplete
- Validation failures during streaming are expected (incomplete XML) and should not trigger error overlay

## Context

During diagram streaming, the XML is often incomplete and fails validation. Using `console.error` triggered the Next.js development error overlay, which was disruptive. Changed to `console.log` to still capture the info for debugging without the visual interruption.