### PR TITLE
chore: update status indicator to show outage resolved

### DIFF
--- a/components/button-with-tooltip.tsx
+++ b/components/button-with-tooltip.tsx
@@ -27,7 +27,7 @@ export function ButtonWithTooltip({
                 <TooltipTrigger asChild>
                     <Button {...buttonProps}>{children}</Button>
                 </TooltipTrigger>
-                <TooltipContent>{tooltipContent}</TooltipContent>
+                <TooltipContent className="max-w-xs text-wrap">{tooltipContent}</TooltipContent>
             </Tooltip>
         </TooltipProvider>
     );

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useRef, useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { FaGithub } from "react-icons/fa";
-import { PanelRightClose, PanelRightOpen, AlertTriangle } from "lucide-react";
+import { PanelRightClose, PanelRightOpen, CheckCircle } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -475,12 +475,12 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                             About
                         </Link>
                         <ButtonWithTooltip
-                            tooltipContent="We're experiencing issues with diagram generation. Debugging is in progress."
+                            tooltipContent="Recent generation failures were caused by our AI provider's infrastructure issue, not the app code. After extensive debugging, I've switched providers and observed 30+ minutes of stability. If issues persist, please report on GitHub."
                             variant="ghost"
                             size="icon"
-                            className="h-6 w-6 text-amber-500 hover:text-amber-600"
+                            className="h-6 w-6 text-green-500 hover:text-green-600"
                         >
-                            <AlertTriangle className="h-4 w-4" />
+                            <CheckCircle className="h-4 w-4" />
                         </ButtonWithTooltip>
                     </div>
                     <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

- Updates service status indicator from warning (amber) to resolved (green)
- Changes icon from AlertTriangle to CheckCircle
- Updates tooltip message to explain the issue was with AI provider infrastructure, not app code
- Adds max-width to tooltip to prevent horizontal overflow

## Context

The 503 errors were caused by AWS Bedrock cross-region inference (`global.anthropic.claude-haiku-4-5`) infrastructure issues. After switching to regional inference (`us.anthropic.claude-haiku-4-5`), error rate dropped from 58% to 0%.