### PR TITLE
feat: add confirmation dialog to prevent accidental back navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,6 +32,18 @@ export default function Home() {
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
+    // Show confirmation dialog when user tries to leave the page
+    // This helps prevent accidental navigation from browser back gestures
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            return '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, []);
+
     return (
         <div className="flex h-screen bg-background relative overflow-hidden">
             {/* Mobile warning overlay */}


### PR DESCRIPTION
## Summary

- Adds `beforeunload` event handler to show browser confirmation dialog when navigating away
- Prevents accidental page exits from browser back gestures (right-click + drag left)
- Also helps prevent losing unsaved diagram work on page refresh/close

Closes #80

## Test plan

- [ ] Test right-click drag in draw.io canvas triggers confirmation dialog instead of navigating
- [ ] Test closing tab shows confirmation dialog
- [ ] Test page refresh shows confirmation dialog