### PR TITLE
fix: ensure markdown text in user messages is visible

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -406,7 +406,11 @@ export function ChatMessageDisplay({
                                                     switch (part.type) {
                                                         case "text":
                                                             return (
-                                                                <div key={index} className="prose prose-sm dark:prose-invert max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                                                                <div key={index} className={`prose prose-sm max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${
+                                                                    message.role === "user"
+                                                                        ? "[&_*]:!text-primary-foreground prose-code:bg-white/20"
+                                                                        : "dark:prose-invert"
+                                                                }`}>
                                                                     <ReactMarkdown>{part.text}</ReactMarkdown>
                                                                 </div>
                                                             );


### PR DESCRIPTION
## Summary

- Fixes low contrast text in user message bubbles when using markdown formatting (bold, headings, etc.)
- The `@tailwindcss/typography` prose plugin was overriding text colors, causing formatted text to blend with the dark primary background
- Added `[&_*]:!text-primary-foreground` to force all child elements in user messages to use the correct foreground color

## Test

Type a message with markdown like `**bold text**` in the chat input and verify the text is visible in the user message bubble.