### PR TITLE
fix: add viewport meta tag for mobile layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { GoogleAnalytics } from "@next/third-parties/google";
@@ -17,6 +17,13 @@ const jetbrainsMono = JetBrains_Mono({
     subsets: ["latin"],
     weight: ["400", "500"],
 });
+
+export const viewport: Viewport = {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: false,
+};
 
 export const metadata: Metadata = {
     title: "Next AI Draw.io - AI-Powered Diagram Generator",


### PR DESCRIPTION
## Summary

- Adds viewport meta tag to enable proper mobile rendering
- Without this, mobile browsers render at ~980px virtual width, causing the mobile layout detection (`window.innerWidth < 768`) to fail
- Settings: `device-width`, `initial-scale=1`, `maximum-scale=1`, `user-scalable=false`

## Root cause

The previous mobile layout PR (#109) added responsive layout but the viewport meta tag was missing, so iPhones were still rendering the page at desktop width.