### PR TITLE
fix: make button hover state darker instead of lighter

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-xs hover:brightness-75",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:


### PR DESCRIPTION
## Summary

- Changed button hover state from `hover:bg-primary/90` (lighter) to `hover:brightness-75` (darker)
- The previous behavior made the button lighter on hover which was counterintuitive
- Now the Send button darkens on hover, providing clearer visual feedback