### PR TITLE
fix: force re-render when switching between mobile/desktop layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,6 +74,7 @@ export default function Home() {
     return (
         <div className="h-screen bg-background relative overflow-hidden">
             <ResizablePanelGroup
+                key={isMobile ? "mobile" : "desktop"}
                 direction={isMobile ? "vertical" : "horizontal"}
                 className="h-full"
             >


### PR DESCRIPTION
## Summary

- Adds a `key` prop to `ResizablePanelGroup` that changes based on `isMobile` state
- This forces React to completely re-render the panel group when switching between mobile and desktop layouts
- Fixes issue where the layout direction wouldn't update properly after initial server-side render

## Root cause

The `ResizablePanelGroup` component from `react-resizable-panels` doesn't properly handle dynamic `direction` prop changes. By adding a key that changes with `isMobile`, we force a full re-mount of the component when the layout mode changes.