### PR TITLE
fix: revert maxDuration to static value (Next.js requirement)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/langfuse"
 import { getSystemPrompt } from "@/lib/system-prompts"
 
-export const maxDuration = Number(process.env.MAX_DURATION) || 60
+export const maxDuration = 300
 
 // File upload limits (must match client-side)
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB

--- a/env.example
+++ b/env.example
@@ -50,6 +50,3 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Access Control (Optional)
 # ACCESS_CODE_LIST=your-secret-code,another-code
-
-# API Route Configuration (Optional)
-# MAX_DURATION=60  # Max duration in seconds for API routes (default: 60)


### PR DESCRIPTION
## Summary
- Revert maxDuration to static value (300)
- Next.js route segment config requires static values at build time
- Remove MAX_DURATION from env.example