### PR TITLE
fix: set maxDuration to 60 for Vercel hobby plan

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/langfuse"
 import { getSystemPrompt } from "@/lib/system-prompts"
 
-export const maxDuration = 300
+export const maxDuration = 60
 
 // File upload limits (must match client-side)
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB


### PR DESCRIPTION
Vercel hobby plan limits maxDuration to 60 seconds