### PR TITLE
fix: add deps: @opentelemetry/exporter-trace-otlp-http version 0.208.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@langfuse/tracing": "^4.4.9",
         "@next/third-parties": "^16.0.6",
         "@openrouter/ai-sdk-provider": "^1.2.3",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
         "@opentelemetry/sdk-trace-node": "^2.2.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-scroll-area": "^1.2.3",


### PR DESCRIPTION
The @langfuse/otel package required @opentelemetry/exporter-trace-otlp-http as a peer dependency, which was missing from the project.

# Error Info

```bash
yarn dev
yarn run v1.22.22
$ next dev --turbopack --port 6002
   ▲ Next.js 16.0.7 (Turbopack)
   - Local:         http://localhost:6002
   - Network:       http://192.168.31.164:6002
   - Environments: .env.local

 ✓ Starting...
 ⨯ ./node_modules/@langfuse/otel/dist/index.mjs:12:1
Module not found: Can't resolve '@opentelemetry/exporter-trace-otlp-http'
  10 | } from "@langfuse/core";
  11 | import { hrTimeToMilliseconds } from "@opentelemetry/core";
> 12 | import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  13 | import {
  14 |   BatchSpanProcessor,
  15 |   SimpleSpanProcessor



Import trace:
  Instrumentation:
    ./node_modules/@langfuse/otel/dist/index.mjs
    ./instrumentation.ts

https://nextjs.org/docs/messages/module-not-found


 ⨯ ./node_modules/@langfuse/otel/dist/index.mjs:12:1
Module not found: Can't resolve '@opentelemetry/exporter-trace-otlp-http'
  10 | } from "@langfuse/core";
  11 | import { hrTimeToMilliseconds } from "@opentelemetry/core";
> 12 | import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  13 | import {
  14 |   BatchSpanProcessor,
  15 |   SimpleSpanProcessor



Import trace:
  Instrumentation:
    ./node_modules/@langfuse/otel/dist/index.mjs
    ./instrumentation.ts

https://nextjs.org/docs/messages/module-not-found


 ⨯ ./node_modules/@langfuse/otel/dist/index.mjs:12:1
Module not found: Can't resolve '@opentelemetry/exporter-trace-otlp-http'
  10 | } from "@langfuse/core";
  11 | import { hrTimeToMilliseconds } from "@opentelemetry/core";
> 12 | import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  13 | import {
  14 |   BatchSpanProcessor,
  15 |   SimpleSpanProcessor



Import trace:
  Edge Instrumentation:
    ./node_modules/@langfuse/otel/dist/index.mjs
    ./instrumentation.ts

https://nextjs.org/docs/messages/module-not-found


 ⨯ ./node_modules/@langfuse/otel/dist/index.mjs:12:1
Module not found: Can't resolve '@opentelemetry/exporter-trace-otlp-http'
  10 | } from "@langfuse/core";
  11 | import { hrTimeToMilliseconds } from "@opentelemetry/core";
> 12 | import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  13 | import {
  14 |   BatchSpanProcessor,
  15 |   SimpleSpanProcessor



Import trace:
  Edge Instrumentation:
    ./node_modules/@langfuse/otel/dist/index.mjs
    ./instrumentation.ts

https://nextjs.org/docs/messages/module-not-found


 ✓ Ready in 2.4s
```