### PR TITLE
feat: verify access code with server before saving

### DIFF
--- a/app/api/verify-access-code/route.ts
+++ b/app/api/verify-access-code/route.ts
@@ -1,0 +1,32 @@
+export async function POST(req: Request) {
+    const accessCodes =
+        process.env.ACCESS_CODE_LIST?.split(",")
+            .map((code) => code.trim())
+            .filter(Boolean) || []
+
+    // If no access codes configured, verification always passes
+    if (accessCodes.length === 0) {
+        return Response.json({
+            valid: true,
+            message: "No access code required",
+        })
+    }
+
+    const accessCodeHeader = req.headers.get("x-access-code")
+
+    if (!accessCodeHeader) {
+        return Response.json(
+            { valid: false, message: "Access code is required" },
+            { status: 401 },
+        )
+    }
+
+    if (!accessCodes.includes(accessCodeHeader)) {
+        return Response.json(
+            { valid: false, message: "Invalid access code" },
+            { status: 401 },
+        )
+    }
+
+    return Response.json({ valid: true, message: "Access code is valid" })
+}


### PR DESCRIPTION
## Summary

- Adds server-side verification of access codes before saving to localStorage
- Creates new `/api/verify-access-code` endpoint to validate codes against `ACCESS_CODE_LIST` env
- Shows error message if access code is invalid
- Disables save button during verification

## Changes

- `components/settings-dialog.tsx`: Added async verification flow with loading and error states
- `app/api/verify-access-code/route.ts`: New API endpoint to verify access codes