### PR TITLE
fix: handle edge cases in chat panel and message display

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -47,7 +47,7 @@ function EditDiffDisplay({ edits }: { edits: EditPair[] }) {
         <div className="space-y-3">
             {edits.map((edit, index) => (
                 <div
-                    key={`${edit.search.slice(0, 50)}-${edit.replace.slice(0, 50)}-${index}`}
+                    key={`${(edit.search || "").slice(0, 50)}-${(edit.replace || "").slice(0, 50)}-${index}`}
                     className="rounded-lg border border-border/50 overflow-hidden bg-background/50"
                 >
                     <div className="px-3 py-1.5 bg-muted/40 border-b border-border/30 flex items-center gap-2">
@@ -177,7 +177,10 @@ export function ChatMessageDisplay({
             const currentXml = xml || ""
             const convertedXml = convertToLegalXml(currentXml)
             if (convertedXml !== previousXML.current) {
-                const replacedXML = replaceNodes(chartXML, convertedXml)
+                // If chartXML is empty, use the converted XML directly
+                const replacedXML = chartXML
+                    ? replaceNodes(chartXML, convertedXml)
+                    : convertedXml
 
                 const validationError = validateMxCellStructure(replacedXML)
                 if (!validationError) {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -347,12 +347,16 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
         })
 
         // Now send the message after state is guaranteed to be updated
+        const accessCode = localStorage.getItem(STORAGE_ACCESS_CODE_KEY) || ""
         sendMessage(
             { parts: userParts },
             {
                 body: {
                     xml: savedXml,
                     sessionId,
+                },
+                headers: {
+                    "x-access-code": accessCode,
                 },
             },
         )
@@ -404,12 +408,16 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
         })
 
         // Now send the edited message after state is guaranteed to be updated
+        const accessCode = localStorage.getItem(STORAGE_ACCESS_CODE_KEY) || ""
         sendMessage(
             { parts: newParts },
             {
                 body: {
                     xml: savedXml,
                     sessionId,
+                },
+                headers: {
+                    "x-access-code": accessCode,
                 },
             },
         )


### PR DESCRIPTION
## Summary

- Handle undefined `edit.search`/`edit.replace` in EditDiffDisplay to prevent runtime errors
- Handle empty `chartXML` when displaying diagrams (use converted XML directly instead of calling `replaceNodes`)
- Add missing access code header to regenerate and edit message handlers

## Test plan

- [ ] Verify regenerate message works with access code enabled
- [ ] Verify edit message works with access code enabled
- [ ] Verify diagrams can be displayed when chartXML is empty