### PR TITLE
feat: Add support for displaying model reasoning/thinking blocks

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -295,6 +295,15 @@ ${lastMessageText}
         model,
         stopWhen: stepCountIs(5),
         messages: allMessages,
+        ...(process.env.ENABLE_REASONING === "true" && {
+            sendReasoning: true,
+            ...(process.env.REASONING_BUDGET_TOKENS && {
+                reasoningBudget: parseInt(process.env.REASONING_BUDGET_TOKENS),
+            }),
+            ...(process.env.REASONING_EFFORT && {
+                reasoningEffort: process.env.REASONING_EFFORT as any,
+            }),
+        }),
         ...(providerOptions && { providerOptions }),
         ...(headers && { headers }),
         // Langfuse telemetry config (returns undefined if not configured)

--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/utils"
 import ExamplePanel from "./chat-example-panel"
 import { CodeBlock } from "./code-block"
+import { ThinkingBlock } from "./thinking-block"
 
 interface EditPair {
     search: string
@@ -598,6 +599,15 @@ export function ChatMessageDisplay({
                                                                             }
                                                                         </ReactMarkdown>
                                                                     </div>
+                                                                )
+                                                            case "reasoning":
+                                                                return (
+                                                                    <ThinkingBlock
+                                                                        key={`${message.id}-reasoning-${index}`}
+                                                                        content={
+                                                                            part.text
+                                                                        }
+                                                                    />
                                                                 )
                                                             case "file":
                                                                 return (

--- a/components/thinking-block.tsx
+++ b/components/thinking-block.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { Brain, ChevronDown, ChevronUp } from "lucide-react"
+import { useState } from "react"
+import Markdown from "react-markdown"
+import { Button } from "./ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card"
+
+interface ThinkingBlockProps {
+    content: string
+}
+
+export function ThinkingBlock({ content }: ThinkingBlockProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+
+    if (!content) {
+        return null
+    }
+
+    return (
+        <Card className="mb-4 bg-gray-50 dark:bg-gray-800 border-l-4 border-blue-500">
+            <CardHeader className="p-3 flex flex-row items-center justify-between space-y-0">
+                <CardTitle className="text-sm font-semibold flex items-center">
+                    <Brain className="w-4 h-4 mr-2 text-blue-500" />
+                    Model Reasoning
+                </CardTitle>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    className="h-auto p-1 text-xs text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900"
+                >
+                    {isExpanded ? (
+                        <>
+                            Hide <ChevronUp className="w-3 h-3 ml-1" />
+                        </>
+                    ) : (
+                        <>
+                            Show <ChevronDown className="w-3 h-3 ml-1" />
+                        </>
+                    )}
+                </Button>
+            </CardHeader>
+            {isExpanded && (
+                <CardContent className="p-3 pt-0 text-sm text-gray-700 dark:text-gray-300">
+                    <Markdown>{content}</Markdown>
+                </CardContent>
+            )}
+        </Card>
+    )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@langfuse/tracing": "^4.4.9",
                 "@next/third-parties": "^16.0.6",
                 "@openrouter/ai-sdk-provider": "^1.2.3",
+                "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
                 "@opentelemetry/sdk-trace-node": "^2.2.0",
                 "@radix-ui/react-dialog": "^1.1.6",
                 "@radix-ui/react-label": "^2.1.8",
@@ -2713,7 +2714,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
             "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
@@ -2753,7 +2753,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.208.0.tgz",
             "integrity": "sha512-jbzDw1q+BkwKFq9yxhjAJ9rjKldbt5AgIy1gmEIJjEV/WRxQ3B6HcLVkwbjJ3RcMif86BDNKR846KJ0tY0aOJA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/otlp-exporter-base": "0.208.0",
@@ -2773,7 +2772,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
             "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/otlp-transformer": "0.208.0"
@@ -2790,7 +2788,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
             "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.208.0",
                 "@opentelemetry/core": "2.2.0",
@@ -2828,7 +2825,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
             "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.208.0",
                 "@opentelemetry/core": "2.2.0",
@@ -2846,7 +2842,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
             "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/resources": "2.2.0"
@@ -2905,36 +2900,31 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
             "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
             "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
             "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
             "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
             "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
                 "@protobufjs/inquire": "^1.1.0"
@@ -2944,36 +2934,31 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
             "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
             "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
             "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@radix-ui/number": {
             "version": "1.1.0",
@@ -9339,8 +9324,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/longest-streak": {
             "version": "3.1.0",
@@ -10917,7 +10901,6 @@
             "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
## Description

This Pull Request implements support for displaying the model's reasoning or thinking blocks in the chat interface, leveraging the built-in functionality of the Vercel AI SDK.

issue #143 

This feature is valuable for:
*   Understanding how the model arrived at a conclusion.
*   Aiding in debugging complex diagram generation.
*   Providing transparency into the model's thought process.

## Changes

1.  **New UI Component:** Added `components/thinking-block.tsx` to render the reasoning content in a collapsible, distinct card.
2.  **Frontend Integration:** Updated `components/chat-message-display.tsx` to correctly handle and render the `reasoning` part type streamed from the AI SDK.
3.  **Backend Configuration:** Modified `app/api/chat/route.ts` to conditionally enable reasoning in the `streamText` call based on environment variables.

## Configuration

To enable this feature, the following environment variables must be set in `.env.local`:

| Variable | Description | Example Value |
| :--- | :--- | :--- |
| `ENABLE_REASONING` | Set to `true` to enable the streaming of reasoning blocks. | `true` |
| `REASONING_BUDGET_TOKENS` | The maximum number of tokens the model can use for its reasoning process. | `12000` |
| `REASONING_EFFORT` | The level of effort the model should put into reasoning. Valid values are `low`, `medium`, or `high`. | `medium` |

## Files Changed

*   `app/api/chat/route.ts`
*   `components/chat-message-display.tsx`
*   `components/thinking-block.tsx` (New file)
*   `package-lock.json` (Updated dependencies)
