### PR TITLE
fix: validate XML before displaying diagram to catch duplicate IDs

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -185,7 +185,8 @@ export function ChatMessageDisplay({
                 const validationError = validateMxCellStructure(replacedXML)
                 if (!validationError) {
                     previousXML.current = convertedXml
-                    onDisplayChart(replacedXML)
+                    // Skip validation in loadDiagram since we already validated above
+                    onDisplayChart(replacedXML, true)
                 } else {
                     console.log(
                         "[ChatMessageDisplay] XML validation failed:",

--- a/components/history-dialog.tsx
+++ b/components/history-dialog.tsx
@@ -32,7 +32,8 @@ export function HistoryDialog({
 
     const handleConfirmRestore = () => {
         if (selectedIndex !== null) {
-            onDisplayChart(diagramHistory[selectedIndex].xml)
+            // Skip validation for trusted history snapshots
+            onDisplayChart(diagramHistory[selectedIndex].xml, true)
             handleClose()
         }
     }


### PR DESCRIPTION
## Summary

- Add validation to `loadDiagram` in diagram-context, returns error string or null
- `display_diagram` and `edit_diagram` tools now check validation result
- Return error to AI agent with `state: output-error` so it can retry
- Skip validation for trusted sources (localStorage, history snapshots, internal templates)
- Add debug logging for tool call inputs to help diagnose Bedrock API issues

## Problem

When AI generates XML with duplicate IDs (e.g., editing a tail element creates duplicate `tailEnd` ID), draw.io shows "Duplicate ID" error but the validation function `validateMxCellStructure` wasn't being called before display.

## Solution

Centralize validation in `loadDiagram` function:
- Returns `string | null` (error message or null if valid)
- AI tool calls check return value and send error back to model for retry
- Trusted sources (localStorage, history, templates) skip validation for performance