### PR TITLE
fix: implement client-side caching for example diagrams

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -676,9 +676,14 @@ export function ChatMessageDisplay({
                                                     <Copy className="h-3.5 w-3.5" />
                                                 )}
                                             </button>
-                                            {/* Regenerate button - only on last assistant message */}
+                                            {/* Regenerate button - only on last assistant message, not for cached examples */}
                                             {onRegenerate &&
-                                                isLastAssistantMessage && (
+                                                isLastAssistantMessage &&
+                                                !message.parts?.some((p: any) =>
+                                                    p.toolCallId?.startsWith(
+                                                        "cached-",
+                                                    ),
+                                                ) && (
                                                     <button
                                                         type="button"
                                                         onClick={() =>


### PR DESCRIPTION
## Summary

- Add client-side cache check in `onFormSubmit` to bypass API calls for example prompts
- Use `findCachedResponse` to match input against cached examples when `messages.length === 0`
- Directly set messages with cached tool response when example matches
- Hide regenerate button for cached example responses (toolCallId starts with `cached-`)

## Why

Previously, clicking an example button and pressing send would:
1. Make an API call to the server
2. Server-side cache check would fail if diagram XML wasn't empty
3. AI would generate a text plan instead of using cached XML

Now, the cache check happens entirely on the client side, bypassing the API completely for matching examples.