### PR TITLE
fix: Save diagram history after edit_diagram tool execution

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -229,7 +229,7 @@ Please fix the edit to avoid structural issues (e.g., duplicate IDs, invalid ref
                         })
                         return
                     }
-
+                    onExport()
                     addToolOutput({
                         tool: "edit_diagram",
                         toolCallId: toolCall.toolCallId,


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The `edit_diagram` tool was not saving diagram snapshots to history, contradicting the system prompt's claim that "the app automatically saves a snapshot before each AI edit." This caused users to lose the ability to restore previous diagram states after making incremental edits with AI.

### Root Cause
- `edit_diagram` only called `loadDiagram()` to render the updated XML
- `loadDiagram()` does not trigger history saving
- History is only saved when `handleExport()` is called with `expectHistoryExportRef.current = true`
- `display_diagram` worked correctly because chat message rendering triggers history via a different flow

### Solution
Added `onExport()` call after successful `edit_diagram` validation:
- Triggers `handleExport()` which sets `expectHistoryExportRef.current = true`  
- Exports diagram with proper SVG rendering
- `handleDiagramExport()` callback checks flag and saves to history
- Maintains consistency with `display_diagram` behavior

### Changes Made
**File: `components/chat-panel.tsx`**
- Added `onExport()` call after validation passes in `edit_diagram` handler (line ~238)
- Ensures history snapshot is saved before success message is sent to AI

### Testing
- ✅ Create diagram with AI using natural language
- ✅ Make incremental edit using `edit_diagram` tool
- ✅ Open history dialog (clock icon)
- ✅ Verify edit is saved as new history entry
- ✅ Restore previous version and confirm it works
- ✅ Verify `display_diagram` continues to work as before

### Before/After Behavior

**Before:**
- User creates diagram → ✅ Saved to history
- User edits with AI → ❌ NOT saved to history  
- User opens history → Only sees initial diagram

**After:**
- User creates diagram → ✅ Saved to history
- User edits with AI → ✅ Saved to history
- User opens history → Sees all diagram states

### Demo

https://github.com/user-attachments/assets/87de799c-e083-4c47-8759-0a317ef3d13d

### Related Issues
Closes #149 

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Comments added for complex logic
- [x] No breaking changes introduced
- [x] Tested locally with multiple scenarios
- [x] System prompt expectations now met
