### PR TITLE
fix(diagram): wrap XML in mxfile structure when canvas is empty

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -177,10 +177,12 @@ export function ChatMessageDisplay({
             const currentXml = xml || ""
             const convertedXml = convertToLegalXml(currentXml)
             if (convertedXml !== previousXML.current) {
-                // If chartXML is empty, use the converted XML directly
-                const replacedXML = chartXML
-                    ? replaceNodes(chartXML, convertedXml)
-                    : convertedXml
+                // If chartXML is empty, create a default mxfile structure to use with replaceNodes
+                // This ensures the XML is properly wrapped in mxfile/diagram/mxGraphModel format
+                const baseXML =
+                    chartXML ||
+                    `<mxfile><diagram name="Page-1" id="page-1"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`
+                const replacedXML = replaceNodes(baseXML, convertedXml)
 
                 const validationError = validateMxCellStructure(replacedXML)
                 if (!validationError) {


### PR DESCRIPTION
## Summary

- Fixes "Not a diagram file" error when clicking an example diagram on a clean page
- When `chartXML` is empty, provides a default mxfile template so `replaceNodes` can properly wrap the content
- DrawIO requires the full `mxfile/diagram/mxGraphModel/root` structure, but the code was previously passing raw `<root>` XML directly

## Root Cause

When the page was clean (no existing diagram), the `handleDisplayChart` function in `chat-message-display.tsx` used this logic:

```javascript
const replacedXML = chartXML
    ? replaceNodes(chartXML, convertedXml)
    : convertedXml  // <-- passed raw <root> XML to DrawIO
```

DrawIO expects the full structure but received only `<root>...</root>`, causing the error.

## Test Plan

- [x] Build passes
- [x] Clicking example diagrams on clean page now works correctly
- [x] No console errors