### PR TITLE
chore: make maxDuration configurable via env variable

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -16,7 +16,7 @@ import {
 } from "@/lib/langfuse"
 import { getSystemPrompt } from "@/lib/system-prompts"
 
-export const maxDuration = 60
+export const maxDuration = parseInt(process.env.MAX_DURATION || "60", 10)
 
 // File upload limits (must match client-side)
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB


### PR DESCRIPTION
## Summary
- Makes `maxDuration` in the chat API route configurable via `MAX_DURATION` environment variable
- Defaults to 60 seconds if not set