### PR TITLE
chore: add Cloudflare-related files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 push-via-ec2.sh
 .claude/settings.local.json
 .playwright-mcp/
+# Cloudflare
+.dev.vars
+.open-next/
+.wrangler/


### PR DESCRIPTION
## Summary

- Adds `.dev.vars`, `.open-next/`, and `.wrangler/` to `.gitignore`
- These are Cloudflare Workers development artifacts that should not be committed

## Problem

Cloudflare Workers development creates local files that were showing up as untracked files.