### PR TITLE
fix: use static maxDuration for Next.js 16 compatibility

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -16,7 +16,7 @@ import {
 } from "@/lib/langfuse"
 import { getSystemPrompt } from "@/lib/system-prompts"
 
-export const maxDuration = parseInt(process.env.MAX_DURATION || "60", 10)
+export const maxDuration = 300
 
 // File upload limits (must match client-side)
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB


### PR DESCRIPTION
## Summary

- Changes `maxDuration` from dynamic `parseInt(process.env.MAX_DURATION || "60", 10)` to static `300`
- Next.js 16 requires segment configuration exports to be static values that can be analyzed at build time
- This fixes the Vercel build error: "Invalid segment configuration export detected"

## Problem

The build was failing with:
```
⨯ Invalid segment configuration export detected. This can cause unexpected behavior from the configs not being applied.
```