### PR TITLE
perf: disable prefetch on About link to reduce requests

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -740,6 +740,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                         {!isMobile && (
                             <Link
                                 href="/about"
+                                prefetch={false}
                                 className="text-sm text-muted-foreground hover:text-foreground transition-colors ml-2"
                             >
                                 About


### PR DESCRIPTION
## Summary

- Disables automatic prefetching on the About page link in the chat panel
- Reduces unnecessary requests to `/about` page when users visit the main page

## Problem

Every visitor to the main page triggered an automatic prefetch request to `/about` because Next.js prefetches linked pages by default. This resulted in high traffic to the about page even when users weren't navigating to it.

## Solution

Added `prefetch={false}` to the About link in `chat-panel.tsx`.