### PR TITLE
chore: redesign usage limits section on about pages

### DIFF
--- a/app/about/cn/page.tsx
+++ b/app/about/cn/page.tsx
@@ -85,12 +85,96 @@ export default function AboutCN() {
                         </div>
                     </div>
 
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
-                        <p className="text-amber-800">
-                            本应用设计运行于 Claude Opus 4.5
-                            以获得最佳性能。但由于流量超出预期，运行顶级模型的成本变得难以承受。为避免服务中断并控制成本，我已将后端切换至
-                            Claude Haiku 4.5。
-                        </p>
+                    <div className="relative mb-8 rounded-2xl bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50 p-[1px] shadow-lg">
+                        <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-400 opacity-20" />
+                        <div className="relative rounded-2xl bg-white/80 backdrop-blur-sm p-6">
+                            {/* Header */}
+                            <div className="mb-4">
+                                <h3 className="text-lg font-bold text-gray-900 tracking-tight">
+                                    关于扩容与限制{" "}
+                                    <span className="text-sm text-amber-600 font-medium italic font-normal">
+                                        (或者说：我的钱包顶不住了)
+                                    </span>
+                                </h3>
+                            </div>
+
+                            {/* Story */}
+                            <div className="space-y-3 text-sm text-gray-700 leading-relaxed mb-5">
+                                <p>
+                                    大家对这个项目的热情太高了——看来大家都真的很喜欢画图！但这也带来了一个幸福的烦恼：我们经常触发出上游
+                                    AI 接口的频率限制
+                                    (TPS/TPM)。一旦超限，系统就会暂停，导致请求失败。
+                                </p>
+                                <p>
+                                    作为一个
+                                    <span className="font-semibold text-amber-700">
+                                        独立开发者
+                                    </span>
+                                    ，目前的 API
+                                    费用全是我自己在掏腰包（纯属为爱发电）。为了保证服务能细水长流，同时也为了避免我个人陷入财务危机，我不得不设置以下临时用量限制：
+                                </p>
+                            </div>
+
+                            {/* Limits Cards */}
+                            <div className="grid grid-cols-2 gap-3 mb-5">
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        Token 用量
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        5万
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /分钟
+                                        </span>
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        50万
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /天
+                                        </span>
+                                    </div>
+                                </div>
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        每日请求数
+                                    </div>
+                                    <div className="text-2xl font-bold text-gray-900">
+                                        20
+                                    </div>
+                                    <div className="text-sm text-gray-600">
+                                        次
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Divider */}
+                            <div className="flex items-center gap-3 my-5">
+                                <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-300 to-transparent" />
+                            </div>
+
+                            {/* Sponsorship CTA */}
+                            <div className="text-center">
+                                <h4 className="text-base font-bold text-gray-900 mb-2">
+                                    寻求赞助 (求大佬捞一把)
+                                </h4>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    要想彻底解除这些限制，扩容后端是唯一的办法。我正在积极寻求
+                                    AI API 提供商或云平台的赞助。
+                                </p>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    作为回报（无论是额度支持还是资金支持），我将在
+                                    GitHub 仓库和 Live Demo
+                                    网站的显眼位置展示贵公司的 Logo
+                                    作为平台赞助商。
+                                </p>
+                                <a
+                                    href="mailto:me@jiang.jp"
+                                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-white font-medium text-sm shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200"
+                                >
+                                    联系我
+                                </a>
+                            </div>
+                        </div>
                     </div>
 
                     <p className="text-gray-700">

--- a/app/about/ja/page.tsx
+++ b/app/about/ja/page.tsx
@@ -93,13 +93,95 @@ export default function AboutJA() {
                         </div>
                     </div>
 
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
-                        <p className="text-amber-800">
-                            本アプリは最高のパフォーマンスを発揮するため、Claude
-                            Opus 4.5
-                            で動作するよう設計されています。しかし、予想以上のトラフィックにより、最上位モデルの運用コストが負担となっています。サービスの中断を避け、コストを管理するため、バックエンドを
-                            Claude Haiku 4.5 に切り替えました。
-                        </p>
+                    <div className="relative mb-8 rounded-2xl bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50 p-[1px] shadow-lg">
+                        <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-400 opacity-20" />
+                        <div className="relative rounded-2xl bg-white/80 backdrop-blur-sm p-6">
+                            {/* Header */}
+                            <div className="mb-4">
+                                <h3 className="text-lg font-bold text-gray-900 tracking-tight">
+                                    利用制限とスケーリングについて{" "}
+                                    <span className="text-sm text-amber-600 font-medium italic font-normal">
+                                        （別名：お財布が悲鳴を上げています）
+                                    </span>
+                                </h3>
+                            </div>
+
+                            {/* Story */}
+                            <div className="space-y-3 text-sm text-gray-700 leading-relaxed mb-5">
+                                <p>
+                                    予想以上の反響をいただき、ありがとうございます！皆様にダイアグラム作成を楽しんでいただいているのは嬉しい限りですが、その熱量により
+                                    AI API のレート制限 (TPS/TPM)
+                                    に頻繁に引っかかってしまっています。制限に達するとシステムが一時停止し、エラーが発生してしまいます。
+                                </p>
+                                <p>
+                                    私は現在、
+                                    <span className="font-semibold text-amber-700">
+                                        個人開発者
+                                    </span>
+                                    として API
+                                    費用を全額自腹で負担しています。サービスを継続し、かつ私自身が借金を背負わないようにするため（笑）、一時的に以下の利用制限を設けさせていただきました。
+                                </p>
+                            </div>
+
+                            {/* Limits Cards */}
+                            <div className="grid grid-cols-2 gap-3 mb-5">
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        トークン使用量
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        5万
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /分
+                                        </span>
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        50万
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /日
+                                        </span>
+                                    </div>
+                                </div>
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        1日のリクエスト数
+                                    </div>
+                                    <div className="text-2xl font-bold text-gray-900">
+                                        20
+                                    </div>
+                                    <div className="text-sm text-gray-600">
+                                        回
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Divider */}
+                            <div className="flex items-center gap-3 my-5">
+                                <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-300 to-transparent" />
+                            </div>
+
+                            {/* Sponsorship CTA */}
+                            <div className="text-center">
+                                <h4 className="text-base font-bold text-gray-900 mb-2">
+                                    スポンサー募集
+                                </h4>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    これらの制限を取り払い、バックエンドをスケールさせるには皆様の支援が必要です。現在、AI
+                                    API
+                                    プロバイダー様やクラウドプラットフォーム様からのスポンサー支援を積極的に募集しています。
+                                </p>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    ご支援（クレジット提供や資金援助）をいただける場合、GitHub
+                                    リポジトリおよびデモサイトにて、プラットフォームスポンサーとして貴社を大々的にご紹介させていただきます。
+                                </p>
+                                <a
+                                    href="mailto:me@jiang.jp"
+                                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-white font-medium text-sm shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200"
+                                >
+                                    お問い合わせ
+                                </a>
+                            </div>
+                        </div>
                     </div>
 
                     <p className="text-gray-700">

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -93,15 +93,104 @@ export default function About() {
                         </div>
                     </div>
 
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
-                        <p className="text-amber-800">
-                            This app is designed to run on Claude Opus 4.5 for
-                            best performance. However, due to
-                            higher-than-expected traffic, running the top-tier
-                            model has become cost-prohibitive. To avoid service
-                            interruptions and manage costs, I have switched the
-                            backend to Claude Haiku 4.5.
-                        </p>
+                    <div className="relative mb-8 rounded-2xl bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50 p-[1px] shadow-lg">
+                        <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-400 opacity-20" />
+                        <div className="relative rounded-2xl bg-white/80 backdrop-blur-sm p-6">
+                            {/* Header */}
+                            <div className="mb-4">
+                                <h3 className="text-lg font-bold text-gray-900 tracking-tight">
+                                    Usage Limits & Scaling{" "}
+                                    <span className="text-sm text-amber-600 font-medium italic font-normal">
+                                        (Or: Why My Wallet is Crying)
+                                    </span>
+                                </h3>
+                            </div>
+
+                            {/* Story */}
+                            <div className="space-y-3 text-sm text-gray-700 leading-relaxed mb-5">
+                                <p>
+                                    The response to this project has been
+                                    incredible—you all love making diagrams!
+                                    However, this enthusiasm means we are
+                                    frequently hitting the AI API rate limits
+                                    (TPS/TPM). When this happens, the system
+                                    pauses, leading to failed requests.
+                                </p>
+                                <p>
+                                    As an{" "}
+                                    <span className="font-semibold text-amber-700">
+                                        indie developer
+                                    </span>
+                                    , I am currently footing the entire API
+                                    bill. To keep the lights on and ensure the
+                                    service remains available to everyone
+                                    without sending me into debt, I have
+                                    implemented the following temporary caps:
+                                </p>
+                            </div>
+
+                            {/* Limits Cards */}
+                            <div className="grid grid-cols-2 gap-3 mb-5">
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        Token Usage
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        50k
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /min
+                                        </span>
+                                    </div>
+                                    <div className="text-lg font-bold text-gray-900">
+                                        500k
+                                        <span className="text-sm font-normal text-gray-600">
+                                            /day
+                                        </span>
+                                    </div>
+                                </div>
+                                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-4 text-center">
+                                    <div className="text-xs font-medium text-amber-700 uppercase tracking-wide mb-1">
+                                        Daily Requests
+                                    </div>
+                                    <div className="text-2xl font-bold text-gray-900">
+                                        20
+                                    </div>
+                                    <div className="text-sm text-gray-600">
+                                        requests
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Divider */}
+                            <div className="flex items-center gap-3 my-5">
+                                <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-300 to-transparent" />
+                            </div>
+
+                            {/* Sponsorship CTA */}
+                            <div className="text-center">
+                                <h4 className="text-base font-bold text-gray-900 mb-2">
+                                    Call for Sponsorship
+                                </h4>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    Scaling the backend is the only way to
+                                    remove these limits. I am actively seeking
+                                    sponsorship from AI API providers or Cloud
+                                    Platforms.
+                                </p>
+                                <p className="text-sm text-gray-600 mb-4 max-w-md mx-auto">
+                                    In return for support (credits or funding),
+                                    I will prominently feature your company as a
+                                    platform sponsor on both the GitHub
+                                    repository and the live demo site.
+                                </p>
+                                <a
+                                    href="mailto:me@jiang.jp"
+                                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-white font-medium text-sm shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200"
+                                >
+                                    Contact Me
+                                </a>
+                            </div>
+                        </div>
                     </div>
 
                     <p className="text-gray-700">

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -6,7 +6,7 @@ import {
     lastAssistantMessageIsCompleteWithToolCalls,
 } from "ai"
 import {
-    CheckCircle,
+    AlertTriangle,
     PanelRightClose,
     PanelRightOpen,
     Settings,
@@ -1034,21 +1034,28 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                         {!isMobile && (
                             <Link
                                 href="/about"
-                                prefetch={false}
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 className="text-sm text-muted-foreground hover:text-foreground transition-colors ml-2"
                             >
                                 About
                             </Link>
                         )}
                         {!isMobile && (
-                            <ButtonWithTooltip
-                                tooltipContent="Recent generation failures were caused by our AI provider's infrastructure issue, not the app code. After extensive debugging, I've switched providers and observed 6 hours of stability. If issues persist, please report on GitHub."
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 text-green-500 hover:text-green-600"
+                            <Link
+                                href="/about"
+                                target="_blank"
+                                rel="noopener noreferrer"
                             >
-                                <CheckCircle className="h-4 w-4" />
-                            </ButtonWithTooltip>
+                                <ButtonWithTooltip
+                                    tooltipContent="Due to high usage, I have added usage limits. See About page for details."
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6 text-amber-500 hover:text-amber-600"
+                                >
+                                    <AlertTriangle className="h-4 w-4" />
+                                </ButtonWithTooltip>
+                            </Link>
                         )}
                     </div>
                     <div className="flex items-center gap-1">

--- a/components/quota-limit-toast.tsx
+++ b/components/quota-limit-toast.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Coffee, X } from "lucide-react"
+import Link from "next/link"
 import type React from "react"
 import { FaGithub } from "react-icons/fa"
 
@@ -70,7 +71,15 @@ export function QuotaLimitToast({
                     Oops — you've reached the daily{" "}
                     {isTokenLimit ? "token" : "API"} limit for this demo! As an
                     indie developer covering all the API costs myself, I have to
-                    set these limits to keep things sustainable.
+                    set these limits to keep things sustainable.{" "}
+                    <Link
+                        href="/about"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-amber-600 font-medium hover:text-amber-700 hover:underline"
+                    >
+                        Learn more →
+                    </Link>
                 </p>
                 <p>
                     The good news is that you can self-host the project in


### PR DESCRIPTION
## Summary

- Redesigned usage limits card with gradient border and modern styling across all 3 language pages (EN/CN/JP)
- Removed emojis and combined title/subtitle on same line for cleaner look
- Added warning triangle icon in chat panel linking to about page
- Added "Learn more" link in quota limit toast
- All about page links now open in new tab to preserve diagram state

## Problem Solved

Users clicking the "About" link or "Learn more" link would lose their diagram when navigating away. Now all links open in a new tab, preserving user's work.