### PR TITLE
docs: add offline deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 Replace the environment variables with your preferred AI provider configuration. See [Multi-Provider Support](#multi-provider-support) for available options.
 
-> **Corporate Networks:** If `embed.diagrams.net` is blocked, see [Self-Hosted Draw.io](./docs/self-hosted-drawio.md) for configuration options.
+> **Offline Deployment:** If `embed.diagrams.net` is blocked, see [Offline Deployment](./docs/offline-deployment.md) for configuration options.
 
 ### Installation
 

--- a/docs/offline-deployment.md
+++ b/docs/offline-deployment.md
@@ -1,0 +1,75 @@
+# Offline Deployment
+
+In some corporate environments, `embed.diagrams.net` is blocked by network policies. This guide explains how to deploy Next AI Draw.io in offline/air-gapped environments using a self-hosted draw.io instance.
+
+## Overview
+
+By default, Next AI Draw.io uses `embed.diagrams.net` for the diagram editor. For offline deployment, you need to:
+
+1. Run a local draw.io instance
+2. Build Next AI Draw.io with a custom `NEXT_PUBLIC_DRAWIO_BASE_URL`
+
+**Important:** This is a **build-time** configuration. You need to rebuild the Docker image to change the draw.io URL.
+
+## Quick Start
+
+### 1. Run Local Draw.io
+
+```bash
+docker run -d -p 8080:8080 jgraph/drawio:latest
+```
+
+### 2. Build Next AI Draw.io
+
+```bash
+docker build --build-arg NEXT_PUBLIC_DRAWIO_BASE_URL=http://localhost:8080 -t next-ai-draw-io .
+```
+
+### 3. Run the Application
+
+```bash
+docker run -d -p 3000:3000 --env-file .env next-ai-draw-io
+```
+
+## Docker Compose
+
+For a complete offline setup with both services:
+
+```yaml
+services:
+  drawio:
+    image: jgraph/drawio:latest
+    ports:
+      - "8080:8080"
+
+  next-ai-draw-io:
+    build:
+      context: .
+      args:
+        - NEXT_PUBLIC_DRAWIO_BASE_URL=http://drawio:8080
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+```
+
+## Local Development
+
+For local development, add to your `.env.local`:
+
+```bash
+NEXT_PUBLIC_DRAWIO_BASE_URL=http://localhost:8080
+```
+
+Then rebuild the application:
+
+```bash
+npm run build
+npm run start
+```
+
+## Notes
+
+- The default draw.io URL is `https://embed.diagrams.net`
+- Changes to `NEXT_PUBLIC_DRAWIO_BASE_URL` require rebuilding (it's baked into the Next.js bundle at build time)
+- You still need network access to your AI provider (OpenAI, Anthropic, etc.) unless using a local model like Ollama


### PR DESCRIPTION
## Summary

Add documentation for offline/air-gapped deployment using self-hosted draw.io.

## Problem

Users in corporate environments or air-gapped networks cannot access `embed.diagrams.net`, causing the diagram editor to fail loading.

Related issues: #158, #33, #29, #113, #35, #20

## Changes

- Add `docs/offline-deployment.md` with:
  - Quick start guide for running local draw.io
  - Docker build instructions with `NEXT_PUBLIC_DRAWIO_BASE_URL`
  - Docker Compose example for complete offline setup
  - Local development configuration
- Update README.md with link to the new guide