### PR TITLE
Fix/clipboard

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -134,30 +134,33 @@ export function ChatMessageDisplay({
 
     const copyMessageToClipboard = async (messageId: string, text: string) => {
         try {
-            // Check if Clipboard API is available
-            if (!navigator.clipboard || !navigator.clipboard.writeText) {
-                // Fallback: create a temporary textarea for copy
-                const textarea = document.createElement("textarea")
-                textarea.value = text
-                textarea.style.position = "fixed"
-                textarea.style.opacity = "0"
-                document.body.appendChild(textarea)
-                textarea.select()
-                const success = document.execCommand("copy")
-                document.body.removeChild(textarea)
-
-                if (!success) {
-                    throw new Error("Copy command failed")
-                }
-            } else {
-                await navigator.clipboard.writeText(text)
-            }
+            await navigator.clipboard.writeText(text)
             setCopiedMessageId(messageId)
             setTimeout(() => setCopiedMessageId(null), 2000)
         } catch (err) {
-            console.error("Failed to copy message:", err)
-            setCopyFailedMessageId(messageId)
-            setTimeout(() => setCopyFailedMessageId(null), 2000)
+            // Fallback for non-secure contexts (HTTP) or permission denied
+            const textarea = document.createElement("textarea")
+            textarea.value = text
+            textarea.style.position = "fixed"
+            textarea.style.left = "-9999px"
+            textarea.style.opacity = "0"
+            document.body.appendChild(textarea)
+
+            try {
+                textarea.select()
+                const success = document.execCommand("copy")
+                if (!success) {
+                    throw new Error("Copy command failed")
+                }
+                setCopiedMessageId(messageId)
+                setTimeout(() => setCopiedMessageId(null), 2000)
+            } catch (fallbackErr) {
+                console.error("Failed to copy message:", fallbackErr)
+                setCopyFailedMessageId(messageId)
+                setTimeout(() => setCopyFailedMessageId(null), 2000)
+            } finally {
+                document.body.removeChild(textarea)
+            }
         }
     }
 


### PR DESCRIPTION
修复了本地部署在交互栏中点击复制按钮出现×号且未能复制的问题。
已在本地进行测试，可以复制用户自己的内容，也可以复制模型的输出内容。