### PR TITLE
chore: improve offline deployment guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 push-via-ec2.sh
-.claude/settings.local.json
+.claude/
 .playwright-mcp/
 # Cloudflare
 .dev.vars

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker run -d -p 3000:3000 \
   ghcr.io/dayuanjiang/next-ai-draw-io:latest
 ```
 
-Or use an env file (create one from `env.example`):
+Or use an env file:
 
 ```bash
 cp env.example .env

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -114,7 +114,7 @@ docker run -d -p 3000:3000 \
   ghcr.io/dayuanjiang/next-ai-draw-io:latest
 ```
 
-或者使用 env 文件（从 `env.example` 创建）：
+或者使用 env 文件：
 
 ```bash
 cp env.example .env

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -114,7 +114,7 @@ docker run -d -p 3000:3000 \
   ghcr.io/dayuanjiang/next-ai-draw-io:latest
 ```
 
-または env ファイルを使用（`env.example` から作成）：
+または env ファイルを使用：
 
 ```bash
 cp env.example .env

--- a/docs/offline-deployment.md
+++ b/docs/offline-deployment.md
@@ -13,27 +13,7 @@ By default, Next AI Draw.io uses `embed.diagrams.net` for the diagram editor. Fo
 
 ## Quick Start
 
-### 1. Run Local Draw.io
-
-```bash
-docker run -d -p 8080:8080 jgraph/drawio:latest
-```
-
-### 2. Build Next AI Draw.io
-
-```bash
-docker build --build-arg NEXT_PUBLIC_DRAWIO_BASE_URL=http://localhost:8080 -t next-ai-draw-io .
-```
-
-### 3. Run the Application
-
-```bash
-docker run -d -p 3000:3000 --env-file .env next-ai-draw-io
-```
-
-## Docker Compose
-
-For a complete offline setup with both services:
+Create a `docker-compose.yml`:
 
 ```yaml
 services:
@@ -51,25 +31,33 @@ services:
       - "3000:3000"
     env_file:
       - .env
+    depends_on:
+      - drawio
+```
+
+Then run:
+
+```bash
+docker compose up -d
 ```
 
 ## Local Development
 
-For local development, add to your `.env.local`:
+1. Start a local draw.io instance:
+
+```bash
+docker run -d -p 8080:8080 jgraph/drawio:latest
+```
+
+2. Add to your `.env.local`:
 
 ```bash
 NEXT_PUBLIC_DRAWIO_BASE_URL=http://localhost:8080
 ```
 
-Then rebuild the application:
+3. Rebuild and run:
 
 ```bash
 npm run build
 npm run start
 ```
-
-## Notes
-
-- The default draw.io URL is `https://embed.diagrams.net`
-- Changes to `NEXT_PUBLIC_DRAWIO_BASE_URL` require rebuilding (it's baked into the Next.js bundle at build time)
-- You still need network access to your AI provider (OpenAI, Anthropic, etc.) unless using a local model like Ollama


### PR DESCRIPTION
## Summary

- Restructured offline deployment docs to use Docker Compose as the primary method (since it requires two services: draw.io + the app)
- Added clear step-by-step instructions for local development
- Updated all 3 READMEs (EN, CN, JA) for consistency
- Updated .gitignore to ignore entire .claude/ directory