### PR TITLE
fix: improve LLM diagram context awareness and image preview

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -764,6 +764,15 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     }
                 }
 
+                // Get previous XML from the last snapshot (before this message)
+                const snapshotKeys = Array.from(
+                    xmlSnapshotsRef.current.keys(),
+                ).sort((a, b) => b - a)
+                const previousXml =
+                    snapshotKeys.length > 0
+                        ? xmlSnapshotsRef.current.get(snapshotKeys[0]) || ""
+                        : ""
+
                 // Save XML snapshot for this message (will be at index = current messages.length)
                 const messageIndex = messages.length
                 xmlSnapshotsRef.current.set(messageIndex, chartXml)
@@ -805,6 +814,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     {
                         body: {
                             xml: chartXml,
+                            previousXml,
                             sessionId,
                         },
                         headers: {
@@ -869,6 +879,15 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
             return
         }
 
+        // Get previous XML (snapshot before the one being regenerated)
+        const snapshotKeys = Array.from(xmlSnapshotsRef.current.keys())
+            .filter((k) => k < userMessageIndex)
+            .sort((a, b) => b - a)
+        const previousXml =
+            snapshotKeys.length > 0
+                ? xmlSnapshotsRef.current.get(snapshotKeys[0]) || ""
+                : ""
+
         // Restore the diagram to the saved state (skip validation for trusted snapshots)
         onDisplayChart(savedXml, true)
 
@@ -923,6 +942,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
             {
                 body: {
                     xml: savedXml,
+                    previousXml,
                     sessionId,
                 },
                 headers: {
@@ -955,6 +975,15 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
             )
             return
         }
+
+        // Get previous XML (snapshot before the one being edited)
+        const snapshotKeys = Array.from(xmlSnapshotsRef.current.keys())
+            .filter((k) => k < messageIndex)
+            .sort((a, b) => b - a)
+        const previousXml =
+            snapshotKeys.length > 0
+                ? xmlSnapshotsRef.current.get(snapshotKeys[0]) || ""
+                : ""
 
         // Restore the diagram to the saved state (skip validation for trusted snapshots)
         onDisplayChart(savedXml, true)
@@ -1018,6 +1047,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
             {
                 body: {
                     xml: savedXml,
+                    previousXml,
                     sessionId,
                 },
                 headers: {

--- a/components/file-preview-list.tsx
+++ b/components/file-preview-list.tsx
@@ -48,6 +48,8 @@ export function FilePreviewList({ files, onRemoveFile }: FilePreviewListProps) {
             imageUrlsRef.current.forEach((url) => {
                 URL.revokeObjectURL(url)
             })
+            // Clear the ref so StrictMode remount creates fresh URLs
+            imageUrlsRef.current = new Map()
         }
     }, [])
 
@@ -83,6 +85,7 @@ export function FilePreviewList({ files, onRemoveFile }: FilePreviewListProps) {
                                         width={80}
                                         height={80}
                                         className="object-cover w-full h-full"
+                                        unoptimized
                                     />
                                 ) : (
                                     <div className="flex items-center justify-center h-full text-xs text-center p-1">
@@ -124,6 +127,7 @@ export function FilePreviewList({ files, onRemoveFile }: FilePreviewListProps) {
                             height={900}
                             className="object-contain max-w-full max-h-[90vh] w-auto h-auto"
                             onClick={(e) => e.stopPropagation()}
+                            unoptimized
                         />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- Replace historical tool call XML inputs with placeholders to reduce tokens and prevent LLM confusion
- Send both previous and current diagram XML so LLM can understand user's manual edits in draw.io
- Mark current XML as authoritative source of truth in system message
- Fix broken image preview when selecting example files (React StrictMode issue with blob URLs)

## Problem

1. **LLM Context Issue**: When users manually added shapes in draw.io, the LLM only saw what it had previously generated (from conversation history) instead of the current diagram state. This caused confusion when the current XML showed 3 triangles but history showed only 1.

2. **Image Preview Bug**: Example file selection broke with `ERR_FILE_NOT_FOUND` errors. React StrictMode runs effects twice - cleanup revoked blob URLs, then second mount tried to reuse them.

## Changes

- `app/api/chat/route.ts`: Added `replaceHistoricalToolInputs()`, extract and include `previousXml` in system message
- `components/chat-panel.tsx`: Send `previousXml` in form submit, regenerate, and edit handlers  
- `components/file-preview-list.tsx`: Clear ref on cleanup for StrictMode compatibility, add `unoptimized` to Image

## Test plan

- [ ] Create a diagram, manually add shapes in draw.io, verify LLM sees all shapes
- [ ] Select an example from the chat panel, verify image preview displays correctly
- [ ] Verify regenerate and edit message features work with previousXml