### PR TITLE
fix: implement AZURE_RESOURCE_NAME config for Azure OpenAI

### DIFF
--- a/env.example
+++ b/env.example
@@ -41,9 +41,13 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 # GOOGLE_THINKING_LEVEL=high                 # Optional: Gemini 3 thinking level (low/high)
 
 # Azure OpenAI Configuration
+# Configure endpoint using ONE of these methods:
+#   1. AZURE_RESOURCE_NAME - SDK constructs: https://{name}.openai.azure.com/openai/v1{path}
+#   2. AZURE_BASE_URL - SDK appends /v1{path} to your URL
+# If both are set, AZURE_BASE_URL takes precedence.
 # AZURE_RESOURCE_NAME=your-resource-name
 # AZURE_API_KEY=...
-# AZURE_BASE_URL=https://your-resource.openai.azure.com  # Optional: Custom endpoint (overrides resourceName)
+# AZURE_BASE_URL=https://your-resource.openai.azure.com/openai  # Alternative: Custom endpoint
 # AZURE_REASONING_EFFORT=low                 # Optional: Azure reasoning effort (low, medium, high)
 # AZURE_REASONING_SUMMARY=detailed
 

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -572,10 +572,15 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
         case "azure": {
             const apiKey = overrides?.apiKey || process.env.AZURE_API_KEY
             const baseURL = overrides?.baseUrl || process.env.AZURE_BASE_URL
-            if (baseURL || overrides?.apiKey) {
+            const resourceName = process.env.AZURE_RESOURCE_NAME
+            // Azure requires either baseURL or resourceName to construct the endpoint
+            // resourceName constructs: https://{resourceName}.openai.azure.com/openai/v1{path}
+            if (baseURL || resourceName || overrides?.apiKey) {
                 const customAzure = createAzure({
                     apiKey,
+                    // baseURL takes precedence over resourceName per SDK behavior
                     ...(baseURL && { baseURL }),
+                    ...(!baseURL && resourceName && { resourceName }),
                 })
                 model = customAzure(modelId)
             } else {


### PR DESCRIPTION
## Summary

- Implements `AZURE_RESOURCE_NAME` environment variable support for Azure OpenAI configuration
- Previously this was documented in `env.example` but not actually used in the code
- Updated `env.example` with clearer documentation on Azure configuration options

## Problem

When users set `AZURE_RESOURCE_NAME` as documented in `env.example`, the configuration was silently ignored because the code never read this variable. This caused Azure OpenAI setup to fail.

## Solution

- Read `AZURE_RESOURCE_NAME` from environment and pass it to `createAzure()` 
- The `resourceName` option constructs the endpoint as: `https://{resourceName}.openai.azure.com/openai/v1`
- `baseURL` takes precedence over `resourceName` when both are set
- Users can now choose either:
  - `AZURE_RESOURCE_NAME=your-resource-name` (simpler)
  - `AZURE_BASE_URL=https://your-resource.openai.azure.com/openai` (custom endpoint)

## Configuration Example

```env
# Option 1: Use resource name (recommended)
AZURE_RESOURCE_NAME=your-resource-name
AZURE_API_KEY=your-api-key
AI_MODEL=your-deployment-name

# Option 2: Use custom base URL
AZURE_BASE_URL=https://your-resource.openai.azure.com/openai
AZURE_API_KEY=your-api-key
AI_MODEL=your-deployment-name
```

Fixes #208