### PR TITLE
fix: disable history XML replacement by default

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -264,8 +264,13 @@ ${lastMessageText}
     // Fix tool call inputs for Bedrock API (requires JSON objects, not strings)
     const fixedMessages = fixToolCallInputs(modelMessages)
 
-    // Replace historical tool call XML with placeholders to reduce tokens and avoid confusion
-    const placeholderMessages = replaceHistoricalToolInputs(fixedMessages)
+    // Replace historical tool call XML with placeholders to reduce tokens
+    // Disabled by default - some models (e.g. minimax) copy placeholders instead of generating XML
+    const enableHistoryReplace =
+        process.env.ENABLE_HISTORY_XML_REPLACE === "true"
+    const placeholderMessages = enableHistoryReplace
+        ? replaceHistoricalToolInputs(fixedMessages)
+        : fixedMessages
 
     // Filter out messages with empty content arrays (Bedrock API rejects these)
     // This is a safety measure - ideally convertToModelMessages should handle all cases


### PR DESCRIPTION
## Summary

Fixes infinite loop issue with certain AI models (e.g. minimax) that copy placeholder text instead of generating fresh XML.

- Added `ENABLE_HISTORY_XML_REPLACE` env var (default: `false`)
- When disabled, historical tool call XML is preserved in conversation context
- Can be enabled for models like Claude that handle placeholders correctly