### PR TITLE
Persist processed tool calls to prevent replay after chat restore

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -19,6 +19,7 @@ import {
     X,
 } from "lucide-react"
 import Image from "next/image"
+import type { MutableRefObject } from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import {
@@ -169,6 +170,7 @@ interface ChatMessageDisplayProps {
     messages: UIMessage[]
     setInput: (input: string) => void
     setFiles: (files: File[]) => void
+    processedToolCallsRef: MutableRefObject<Set<string>>
     sessionId?: string
     onRegenerate?: (messageIndex: number) => void
     onEditMessage?: (messageIndex: number, newText: string) => void
@@ -179,6 +181,7 @@ export function ChatMessageDisplay({
     messages,
     setInput,
     setFiles,
+    processedToolCallsRef,
     sessionId,
     onRegenerate,
     onEditMessage,
@@ -187,7 +190,7 @@ export function ChatMessageDisplay({
     const { chartXML, loadDiagram: onDisplayChart } = useDiagram()
     const messagesEndRef = useRef<HTMLDivElement>(null)
     const previousXML = useRef<string>("")
-    const processedToolCalls = useRef<Set<string>>(new Set())
+    const processedToolCalls = processedToolCallsRef
     const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>(
         {},
     )

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -189,6 +189,9 @@ export default function ChatPanel({
     // Ref to track consecutive auto-retry count (reset on user action)
     const autoRetryCountRef = useRef(0)
 
+    // Persist processed tool call IDs so collapsing the chat doesn't replay old tool outputs
+    const processedToolCallsRef = useRef<Set<string>>(new Set())
+
     const {
         messages,
         sendMessage,
@@ -1081,6 +1084,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     messages={messages}
                     setInput={setInput}
                     setFiles={handleFileChange}
+                    processedToolCallsRef={processedToolCallsRef}
                     sessionId={sessionId}
                     onRegenerate={handleRegenerate}
                     status={status}


### PR DESCRIPTION
## Summary
- persist processed tool call IDs at the chat panel level
- pass the set into the message display to avoid reprocessing on collapse/restore
- keep manual edits intact when reopening the chat window

issue #210 