### PR TITLE
fix:custom model setting bug

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -801,15 +801,14 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     "x-access-code": config.accessCode,
                     ...(config.aiProvider && {
                         "x-ai-provider": config.aiProvider,
-                    }),
-                    ...(config.aiProvider &&
-                        config.aiBaseUrl && {
+                        ...(config.aiBaseUrl && {
                             "x-ai-base-url": config.aiBaseUrl,
                         }),
-                    ...(config.aiProvider &&
-                        config.aiApiKey && { "x-ai-api-key": config.aiApiKey }),
-                    ...(config.aiProvider &&
-                        config.aiModel && { "x-ai-model": config.aiModel }),
+                        ...(config.aiApiKey && {
+                            "x-ai-api-key": config.aiApiKey,
+                        }),
+                        ...(config.aiModel && { "x-ai-model": config.aiModel }),
+                    }),
                 },
             },
         )


### PR DESCRIPTION
Fixed https://github.com/DayuanJiang/next-ai-draw-io/issues/226

When the Provider is selected as Usu Server Default, the request will no longer pass x-ai-base-url, x-ai-api-key, x-ai-model
