### PR TITLE
fix: add user feedback for clipboard copy failures

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -22,6 +22,7 @@ import Image from "next/image"
 import type { MutableRefObject } from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
+import { toast } from "sonner"
 import {
     Reasoning,
     ReasoningContent,
@@ -234,6 +235,9 @@ export function ChatMessageDisplay({
                 setTimeout(() => setCopiedMessageId(null), 2000)
             } catch (fallbackErr) {
                 console.error("Failed to copy message:", fallbackErr)
+                toast.error(
+                    "Failed to copy message. Please copy manually or check clipboard permissions.",
+                )
                 setCopyFailedMessageId(messageId)
                 setTimeout(() => setCopyFailedMessageId(null), 2000)
             } finally {


### PR DESCRIPTION
## Summary

Add toast notification when clipboard copy operation fails, so users are informed when their copy attempt was unsuccessful.

## Changes

- Add toast import from sonner
- Add `toast.error()` notification when clipboard copy fails
- Show clear message: "Failed to copy message. Please copy manually or check clipboard permissions."

## Problem

Previously, clipboard copy failures were only indicated by a brief visual state change (`setCopyFailedMessageId`), which users might easily miss. This was a **silent failure** - users had no persistent indication that their copy attempt failed.

## Solution

When clipboard copy fails (both in the main path and fallback path), show a persistent toast notification that:
- Clearly states the copy operation failed
- Provides actionable guidance (copy manually or check permissions)
- Remains visible long enough for users to read

## Testing

- ✅ Normal clipboard copy works as before
- ✅ Failed clipboard copy shows toast error
- ✅ Error message is clear and actionable