### PR TITLE
fix: revert UI and notify user when feedback submission fails

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -22,6 +22,7 @@ import Image from "next/image"
 import type { MutableRefObject } from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
+import { toast } from "sonner"
 import {
     Reasoning,
     ReasoningContent,
@@ -266,7 +267,14 @@ export function ChatMessageDisplay({
                 }),
             })
         } catch (error) {
-            console.warn("Failed to log feedback:", error)
+            console.error("Failed to log feedback:", error)
+            toast.error("Failed to record your feedback. Please try again.")
+            // Revert optimistic UI update
+            setFeedback((prev) => {
+                const next = { ...prev }
+                delete next[messageId]
+                return next
+            })
         }
     }
 


### PR DESCRIPTION
## Summary

When feedback submission to the API fails, revert the optimistic UI update and show a toast notification to inform the user.

## Changes

- Add toast import from sonner
- Change `console.warn` to `console.error` for proper logging
- Add `toast.error()` notification when API call fails
- Revert optimistic UI update by removing feedback from state

## Problem

Previously, feedback submission failures were **completely silent**. The code optimistically updates the UI (shows thumbs-up/down) before the API call completes. If the API call fails (network error, server error, etc.), users would see the visual feedback but their feedback was never recorded. This creates a false sense that the feedback was successfully submitted.

## Solution

When the API call fails:
1. Show a clear toast notification: "Failed to record your feedback. Please try again."
2. Revert the optimistic UI update by removing the feedback from state
3. Log error properly with `console.error` instead of `console.warn`

Now users know immediately when their feedback wasn't recorded and can retry.

## Testing

- ✅ Normal feedback submission works as before
- ✅ Failed submission shows toast error
- ✅ UI reverts to unfilled state on failure
- ✅ Users can retry after failure