### PR TITLE
chore: optimize Vercel costs

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/langfuse"
 import { getSystemPrompt } from "@/lib/system-prompts"
 
-export const maxDuration = 300
+export const maxDuration = 120
 
 // File upload limits (must match client-side)
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import { GoogleAnalytics } from "@next/third-parties/google"
-import { Analytics } from "@vercel/analytics/react"
 import type { Metadata, Viewport } from "next"
 import { JetBrains_Mono, Plus_Jakarta_Sans } from "next/font/google"
 import { DiagramProvider } from "@/contexts/diagram-context"
@@ -117,7 +116,6 @@ export default function RootLayout({
                 className={`${plusJakarta.variable} ${jetbrainsMono.variable} antialiased`}
             >
                 <DiagramProvider>{children}</DiagramProvider>
-                <Analytics />
             </body>
             {process.env.NEXT_PUBLIC_GA_ID && (
                 <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "next-ai-draw-io",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "next-ai-draw-io",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/amazon-bedrock": "^3.0.62",
@@ -33,7 +33,6 @@
                 "@radix-ui/react-switch": "^1.2.6",
                 "@radix-ui/react-tooltip": "^1.1.8",
                 "@radix-ui/react-use-controllable-state": "^1.2.2",
-                "@vercel/analytics": "^1.5.0",
                 "@xmldom/xmldom": "^0.9.8",
                 "ai": "^5.0.89",
                 "base-64": "^1.0.0",
@@ -6027,44 +6026,6 @@
             "os": [
                 "win32"
             ]
-        },
-        "node_modules/@vercel/analytics": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
-            "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
-            "license": "MPL-2.0",
-            "peerDependencies": {
-                "@remix-run/react": "^2",
-                "@sveltejs/kit": "^1 || ^2",
-                "next": ">= 13",
-                "react": "^18 || ^19 || ^19.0.0-rc",
-                "svelte": ">= 4",
-                "vue": "^3",
-                "vue-router": "^4"
-            },
-            "peerDependenciesMeta": {
-                "@remix-run/react": {
-                    "optional": true
-                },
-                "@sveltejs/kit": {
-                    "optional": true
-                },
-                "next": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "svelte": {
-                    "optional": true
-                },
-                "vue": {
-                    "optional": true
-                },
-                "vue-router": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/@vercel/oidc": {
             "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
-        "@vercel/analytics": "^1.5.0",
         "@xmldom/xmldom": "^0.9.8",
         "ai": "^5.0.89",
         "base-64": "^1.0.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+    "functions": {
+        "app/api/chat/route.ts": {
+            "memory": 512,
+            "maxDuration": 120
+        },
+        "app/api/**/route.ts": {
+            "memory": 256,
+            "maxDuration": 10
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Created vercel.json with optimized function settings (512MB/120s for chat, 256MB/10s for other APIs)
- Removed @vercel/analytics package and imports
- Reduced chat route maxDuration from 300s to 120s

## Expected Impact
Reduces monthly Vercel costs by $2-4, keeping usage comfortably under the $20 included credit.

## Changes
- **vercel.json**: New file with function memory and timeout configurations
- **app/layout.tsx**: Removed Analytics component and import
- **app/api/chat/route.ts**: Reduced maxDuration from 300 to 120
- **package.json**: Removed @vercel/analytics dependency