### PR TITLE
fix: shorten toast notification duration

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1023,6 +1023,7 @@ Please retry with an adjusted search pattern or use display_diagram if retries a
                     style: {
                         maxWidth: "480px",
                     },
+                    duration: 2000,
                 }}
             />
             {/* Header */}


### PR DESCRIPTION
Reduces toast display duration from default 4 seconds to 2 seconds for a snappier UX.