### PR TITLE
fix: remove overly aggressive message filtering on restore

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -89,37 +89,6 @@ function hasToolErrors(messages: ChatMessage[]): boolean {
     return lastToolPart?.state === TOOL_ERROR_STATE
 }
 
-/**
- * Check if a message contains valid diagram XML.
- * Used to filter out corrupted messages when restoring from localStorage.
- * Validates both display_diagram and append_diagram tool calls.
- */
-function hasValidDiagramXml(message: {
-    parts?: Array<{ type?: string; input?: unknown }>
-}): boolean {
-    if (!message.parts) return true // No parts = valid (user messages, text-only)
-
-    const parser = new DOMParser()
-    for (const part of message.parts) {
-        // Check both display_diagram and append_diagram tools
-        const isDiagramTool =
-            part.type === "tool-display_diagram" ||
-            part.type === "tool-append_diagram"
-        const input = part.input as { xml?: string } | undefined
-        if (isDiagramTool && input?.xml) {
-            try {
-                const doc = parser.parseFromString(input.xml, "text/xml")
-                if (doc.querySelector("parsererror")) {
-                    return false
-                }
-            } catch {
-                return false
-            }
-        }
-    }
-    return true
-}
-
 export default function ChatPanel({
     isVisible,
     onToggleVisibility,
@@ -639,7 +608,6 @@ Continue from EXACTLY where you stopped.`,
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
     // Restore messages and XML snapshots from localStorage on mount
-    // Validates and filters out corrupted messages to prevent crash loops
     useEffect(() => {
         if (hasRestoredRef.current) return
         hasRestoredRef.current = true
@@ -650,32 +618,7 @@ Continue from EXACTLY where you stopped.`,
             if (savedMessages) {
                 const parsed = JSON.parse(savedMessages)
                 if (Array.isArray(parsed) && parsed.length > 0) {
-                    // Filter out messages with invalid XML to prevent crash loops
-                    const validMessages = parsed.filter((msg: ChatMessage) => {
-                        try {
-                            return hasValidDiagramXml(msg)
-                        } catch {
-                            return false
-                        }
-                    })
-
-                    if (validMessages.length < parsed.length) {
-                        const removedCount =
-                            parsed.length - validMessages.length
-                        console.warn(
-                            `[ChatPanel] Filtered ${removedCount} corrupted message(s) from storage`,
-                        )
-                        toast.warning(
-                            `Removed ${removedCount} message(s) with invalid diagrams to recover session.`,
-                        )
-                        // Update storage with cleaned messages
-                        localStorage.setItem(
-                            STORAGE_MESSAGES_KEY,
-                            JSON.stringify(validMessages),
-                        )
-                    }
-
-                    setMessages(validMessages)
+                    setMessages(parsed)
                 }
             }
 


### PR DESCRIPTION
## Summary

Removes the `hasValidDiagramXml` filter that was deleting valid messages with minor XML issues on page refresh.

## Problem

Messages with diagram XML were being deleted on page refresh with toast "Removed X message(s) with invalid diagrams to recover session." This happened even when:
1. The diagram rendered successfully in draw.io
2. The XML only had minor issues that could be handled

## Solution

Remove the message filtering entirely. Error handling in `handleDisplayChart` (`chat-message-display.tsx`) now catches all errors, so filtering is no longer needed - invalid XML just won't load the diagram but the conversation is preserved.