### PR TITLE
fix: edit_diagram streaming and JSON repair improvements

### DIFF
--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -86,20 +86,16 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         chart: string,
         skipValidation?: boolean,
     ): string | null => {
-        console.time("perf:loadDiagram")
         let xmlToLoad = chart
 
         // Validate XML structure before loading (unless skipped for internal use)
         if (!skipValidation) {
-            console.time("perf:loadDiagram-validation")
             const validation = validateAndFixXml(chart)
-            console.timeEnd("perf:loadDiagram-validation")
             if (!validation.valid) {
                 console.warn(
                     "[loadDiagram] Validation error:",
                     validation.error,
                 )
-                console.timeEnd("perf:loadDiagram")
                 return validation.error
             }
             // Use fixed XML if auto-fix was applied
@@ -116,14 +112,11 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         setChartXML(xmlToLoad)
 
         if (drawioRef.current) {
-            console.time("perf:drawio-iframe-load")
             drawioRef.current.load({
                 xml: xmlToLoad,
             })
-            console.timeEnd("perf:drawio-iframe-load")
         }
 
-        console.timeEnd("perf:loadDiagram")
         return null
     }
 


### PR DESCRIPTION
## Summary

- Fix edit_diagram streaming conflict where operations were applied twice (streaming preview + tool handler), causing "cell already exists" errors
- Add JSON repair preprocessing to fix LLM-generated malformed JSON like `:=` instead of `: `
- Filter out tool calls with invalid/undefined inputs from interrupted streaming sessions
- Remove perf console logs

## Problem

The edit_diagram tool was failing with "cell already exists" errors because:
1. Streaming preview applied operations to the diagram
2. Tool handler tried to apply the same operations again to the already-modified diagram

## Solution

Introduced a shared `editDiagramOriginalXmlRef` between `chat-message-display.tsx` (streaming) and `chat-panel.tsx` (tool handler) so both use the same original XML base for applying operations.