### PR TITLE
fix: fix/streaming-ux-indicator

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -327,7 +327,7 @@ export function ChatMessageDisplay({
                     // Next.js dev mode error overlay for expected streaming states
                     // (partial XML during streaming is normal and will be fixed by subsequent updates)
                     if (showToast) {
-                        // Only log as error and show toast if this is the final output
+                        // Only log as error and show toast if this is the final XML
                         console.error(
                             "[ChatMessageDisplay] Malformed XML detected in final output",
                         )
@@ -1358,6 +1358,20 @@ export function ChatMessageDisplay({
                             </div>
                         )
                     })}
+
+                    {/* UX Improvement: Show a "Generating diagram..." indicator during streaming pauses */}
+                    {isLastMessageFromAssistant && status === 'streaming' && (
+                        <div className="flex w-full justify-start animate-message-in">
+                            <div className="max-w-[85%]">
+                                <div className="bg-muted/60 text-foreground rounded-2xl rounded-bl-md px-4 py-3 mt-4">
+                                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                        <div className="h-4 w-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+                                        <span>Generating diagram...</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    )}
                 </div>
             )}
             <div ref={messagesEndRef} />


### PR DESCRIPTION
Summary

This PR introduces support for custom sglang deployments that are OpenAI-compatible
but have minor deviations from the official API specification. It also improves the
frontend user experience by adding a loading indicator for multi-step AI responses.

This resolves issues where the application would fail to display results or appear
unresponsive when connected to a custom sglang service.

Problem

Connecting the application to a custom sglang service revealed three core issues:

Stream Validation Errors: The service's streaming response included a delta object
with role: "", which is not compliant with the Vercel AI SDK's parser, causing
AI_TypeValidationError.
Silent Stream Failure: The delta object also contained a non-standard
reasoning_content: "" field. This caused the AI SDK's parser to silently discard any
data chunks containing tool calls, preventing diagrams from being rendered.
Poor User Experience: Even when the stream was partially working, there was a long
pause between the AI's initial text response and the start of the diagram generation,
making the application feel unresponsive.
Solution

This PR implements a robust, multi-part solution:

Added a sglang AI Provider (lib/ai-providers.ts):

A new sglang provider option has been added.
It uses the createOpenAI factory but with a custom fetch wrapper to intercept
and sanitize the response stream.
Implemented a Stream Transformer (lib/ai-providers.ts):

The custom fetch wrapper pipes the response from the sglang service through a
TransformStream.
This transformer correctly parses Server-Sent Events (SSE) and performs two
cleanup actions on each data chunk before forwarding it to the AI SDK:
Deletes the invalid role: "" from the delta object.
Deletes the non-standard reasoning_content field from the delta object.
This ensures the AI SDK receives a clean, fully compliant data stream, resolving
all parsing and rendering errors.
Improved Frontend Feedback (components/chat-message-display.tsx):

A loading indicator (Generating diagram... with a spinner) has been added to the
chat display.
This indicator now appears whenever the chat is waiting for the assistant to
continue its response (e.g., during the pause between text and tool generation),
providing clear feedback to the user that the AI is still working. This is a
general UX improvement for all providers.
How to Test

Create or update your .env.local file with the following variables:
1 AI_PROVIDER=sglang
2 AI_MODEL=
3 SGLANG_API_KEY=
4 SGLANG_BASE_URL=

Run the application and start a chat.
Ask the AI to draw a diagram.
Verify that:
The initial text response appears.
The "Generating diagram..." indicator appears immediately after.
The diagram is successfully drawn on the canvas.
No errors appear in the browser or server console.



This is the displayed part