### PR TITLE
fix(mcp): sync browser state before get_diagram to prevent data loss

### DIFF
--- a/packages/mcp-server/src/http-server.ts
+++ b/packages/mcp-server/src/http-server.ts
@@ -46,12 +46,15 @@ export function setState(sessionId: string, xml: string, svg?: string): number {
     return newVersion
 }
 
-export function requestSync(sessionId: string): void {
+export function requestSync(sessionId: string): boolean {
     const state = stateStore.get(sessionId)
     if (state) {
         state.syncRequested = Date.now()
         log.debug(`Sync requested for session=${sessionId}`)
+        return true
     }
+    log.debug(`Sync requested for non-existent session=${sessionId}`)
+    return false
 }
 
 export async function waitForSync(


### PR DESCRIPTION
## Problem
When user manually edits diagram in browser (move, resize, change color, etc.) and then asks AI to edit, user's changes were lost because AI was using stale state.

## Solution
- Add sync mechanism: `get_diagram` now requests browser to push current state before returning
- Enforce workflow: `edit_diagram` requires `get_diagram` to be called within 30s
- Browser polls for `syncRequested` flag and immediately pushes fresh XML when set