### PR TITLE
fix: add write permissions to electron build jobs

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fix electron release workflow - build jobs need contents:write to upload assets to release.