### PR TITLE
fix(ci): disable electron-builder auto-publish

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Build Electron app
-        run: npm run dist:${{ matrix.platform }}
+        run: npm run electron:build && npm run electron:prepare && npx electron-builder --${{ matrix.platform }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The previous fix added permissions to the build job, but the real issue was electron-builder's auto-publish feature trying to upload directly to the release when it detects a tag.

This fix adds `--publish never` to the electron-builder command so it only builds artifacts, and lets the workflow's release step handle uploading them via `softprops/action-gh-release`.