### PR TITLE
fix: include instrumentation.ts in standalone build for Langfuse

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
     env: {
         APP_VERSION: packageJson.version,
     },
+    // Include instrumentation.ts in standalone build for Langfuse telemetry
+    outputFileTracingIncludes: {
+        "*": ["./instrumentation.ts"],
+    },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

Fixes Langfuse telemetry not working on AWS App Runner deployments.

- Add `outputFileTracingIncludes` to next.config.ts to ensure instrumentation.ts is included in standalone builds
- Simplify langfuse.ts to use pure OpenTelemetry approach via AI SDK telemetry
- Add success log to confirm instrumentation initialization

## Problem

In standalone mode (`output: "standalone"`), Next.js aggressively prunes files and was not including `instrumentation.ts` in the build. This caused Langfuse telemetry to silently fail on App Runner while working on Vercel (which doesn't use standalone output).