### PR TITLE
debug: add log to verify instrumentation initialization

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -36,4 +36,5 @@ export function register() {
 
     // Register globally so AI SDK's telemetry also uses this processor
     tracerProvider.register()
+    console.log("[Langfuse] Instrumentation initialized successfully")
 }


### PR DESCRIPTION
Adds a console.log to verify if Langfuse instrumentation is being loaded in standalone builds.