### PR TITLE
fix: improve Langfuse span filter to exclude all Next.js infrastructure traces

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -19,10 +19,13 @@ export function register() {
             const spanName = otelSpan.name
             // Skip Next.js HTTP infrastructure spans
             if (
-                spanName.startsWith("POST /") ||
-                spanName.startsWith("GET /") ||
+                spanName.startsWith("POST") ||
+                spanName.startsWith("GET") ||
+                spanName.startsWith("RSC") ||
                 spanName.includes("BaseServer") ||
-                spanName.includes("handleRequest")
+                spanName.includes("handleRequest") ||
+                spanName.includes("resolve page") ||
+                spanName.includes("start response")
             ) {
                 return false
             }


### PR DESCRIPTION
## Summary

- Improves the `shouldExportSpan` filter in `instrumentation.ts` to exclude all Next.js infrastructure traces
- Previously only filtered `GET /` and `POST /` patterns, missing `GET`, `RSC GET`, `RSC GET /[path]`, `resolve page`, and `start response` spans

## Problem

Langfuse was receiving hundreds of unwanted Next.js infrastructure traces (347 GET, 130 RSC GET, etc.) while only 12 actual `chat` traces were relevant.

## Changes

- Filter spans starting with `POST`, `GET`, `RSC`
- Filter spans containing `resolve page`, `start response`