### PR TITLE
chore: hide notice icon from header

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1281,24 +1281,6 @@ Continue from EXACTLY where you stopped.`,
                                     About
                                 </Link>
                             )}
-                        {!isMobile &&
-                            process.env.NEXT_PUBLIC_SHOW_ABOUT_AND_NOTICE ===
-                                "true" && (
-                                <Link
-                                    href="/about"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    <ButtonWithTooltip
-                                        tooltipContent="Due to high usage, I have changed the model to minimax-m2 and added some usage limits. See About page for details."
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-6 w-6 text-amber-500 hover:text-amber-600"
-                                    >
-                                        <AlertTriangle className="h-4 w-4" />
-                                    </ButtonWithTooltip>
-                                </Link>
-                            )}
                     </div>
                     <div className="flex items-center gap-1 justify-end overflow-visible">
                         <ButtonWithTooltip


### PR DESCRIPTION
Remove the AlertTriangle notice icon from the header while keeping the About link.