### PR TITLE
chore: upgrade AI SDK to v6.0.1

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -248,7 +248,7 @@ ${userInputText}
 """`
 
     // Convert UIMessages to ModelMessages and add system message
-    const modelMessages = convertToModelMessages(messages)
+    const modelMessages = await convertToModelMessages(messages)
 
     // DEBUG: Log incoming messages structure
     console.log("[route.ts] Incoming messages count:", messages.length)
@@ -686,7 +686,8 @@ Call this tool to get shape names and usage syntax for a specific library.`,
                 // Total input = non-cached + cached (these are separate counts)
                 // Note: cacheWriteInputTokens is not available on finish part
                 const totalInputTokens =
-                    (usage.inputTokens ?? 0) + (usage.cachedInputTokens ?? 0)
+                    (usage.inputTokens ?? 0) +
+                    (usage.inputTokenDetails?.cacheReadTokens ?? 0)
                 return {
                     inputTokens: totalInputTokens,
                     outputTokens: usage.outputTokens ?? 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
             "version": "0.4.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/amazon-bedrock": "^3.0.70",
-                "@ai-sdk/anthropic": "^2.0.44",
-                "@ai-sdk/azure": "^2.0.69",
-                "@ai-sdk/deepseek": "^1.0.30",
-                "@ai-sdk/gateway": "^2.0.21",
-                "@ai-sdk/google": "^2.0.0",
-                "@ai-sdk/openai": "^2.0.19",
-                "@ai-sdk/react": "^2.0.107",
+                "@ai-sdk/amazon-bedrock": "^4.0.1",
+                "@ai-sdk/anthropic": "^3.0.0",
+                "@ai-sdk/azure": "^3.0.0",
+                "@ai-sdk/deepseek": "^2.0.0",
+                "@ai-sdk/gateway": "^3.0.0",
+                "@ai-sdk/google": "^3.0.0",
+                "@ai-sdk/openai": "^3.0.0",
+                "@ai-sdk/react": "^3.0.1",
                 "@aws-sdk/credential-providers": "^3.943.0",
                 "@formatjs/intl-localematcher": "^0.7.2",
                 "@langfuse/client": "^4.4.9",
                 "@langfuse/otel": "^4.4.4",
                 "@langfuse/tracing": "^4.4.9",
                 "@next/third-parties": "^16.0.6",
-                "@openrouter/ai-sdk-provider": "^1.2.3",
+                "@openrouter/ai-sdk-provider": "^1.5.4",
                 "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
                 "@opentelemetry/sdk-trace-node": "^2.2.0",
                 "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -38,7 +38,7 @@
                 "@radix-ui/react-tooltip": "^1.1.8",
                 "@radix-ui/react-use-controllable-state": "^1.2.2",
                 "@xmldom/xmldom": "^0.9.8",
-                "ai": "^5.0.89",
+                "ai": "^6.0.1",
                 "base-64": "^1.0.0",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
@@ -93,14 +93,14 @@
             }
         },
         "node_modules/@ai-sdk/amazon-bedrock": {
-            "version": "3.0.70",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-3.0.70.tgz",
-            "integrity": "sha512-4NIBlwuS/iLKq2ynOqqyJ9imk/oyHuOzhBx88Bfm5I0ihQPKJ0dMMD1IKKuyDZvLRYKmlOEpa//P+/ZBp10drw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.1.tgz",
+            "integrity": "sha512-8Qu5wHTHYTwptZ1L4Sv8hvXMyKRNWUD6dH8wm+Zl8RDOEXZJNENS6zec7u/sWJKuvefL7j+xN8z3IVduhGfxig==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/anthropic": "2.0.56",
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.19",
+                "@ai-sdk/anthropic": "3.0.0",
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0",
                 "@smithy/eventstream-codec": "^4.0.1",
                 "@smithy/util-utf8": "^4.0.0",
                 "aws4fetch": "^1.0.20"
@@ -112,48 +112,14 @@
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
-        "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.19",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.19.tgz",
-            "integrity": "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.6"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
         "node_modules/@ai-sdk/anthropic": {
-            "version": "2.0.56",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.56.tgz",
-            "integrity": "sha512-XHJKu0Yvfu9SPzRfsAFESa+9T7f2YJY6TxykKMfRsAwpeWAiX/Gbx5J5uM15AzYC3Rw8tVP3oH+j7jEivENirQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.0.tgz",
+            "integrity": "sha512-4BnxkXwRkvh+OB1ze0mHbskT90HL4MNrg6JUsRDkIsU9w5vitvGzxwc/XwlByUGMap/5I8/LZ3XZDzv6KViCuQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.19"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.19",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.19.tgz",
-            "integrity": "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.6"
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -163,31 +129,14 @@
             }
         },
         "node_modules/@ai-sdk/azure": {
-            "version": "2.0.69",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.69.tgz",
-            "integrity": "sha512-0Y+f0XHviWw9ixB2Dkqyg07V67oczUh8adh4B/t0LgVMVkvOsf/WEzfYx2/LDqdvI/o8IYyJ6JzsCKpBwbS61g==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-3.0.0.tgz",
+            "integrity": "sha512-bY1EfX4aisnpOYcuZkmkuBIUc0noNT/25ZoWispSiMZMS53yF55xkT1SFM+cxDjJ4M3HVJwVuU6r1szA8f9IPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/openai": "2.0.67",
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.17"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz",
-            "integrity": "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.6"
+                "@ai-sdk/openai": "3.0.0",
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -197,14 +146,13 @@
             }
         },
         "node_modules/@ai-sdk/deepseek": {
-            "version": "1.0.30",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-1.0.30.tgz",
-            "integrity": "sha512-pafNclW9L8Z3WimaRwlpHrGbdeaDE/UklT3rMi2aoRRyrA+s7zGcFuu1zbO2ViLNlKfaS91XZa9MFAPXbIftUA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.0.tgz",
+            "integrity": "sha512-qRX06mouHaF4OePE4S8W8+fLX7Iq4dWk7Ul4+SSPBzx6zBJKUqwHYW2XyPShNWhT4Rcogpl5yHJUrBaOExkiyg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/openai-compatible": "1.0.28",
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.18"
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -214,13 +162,13 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "2.0.21",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.21.tgz",
-            "integrity": "sha512-BwV7DU/lAm3Xn6iyyvZdWgVxgLu3SNXzl5y57gMvkW4nGhAOV5269IrJzQwGt03bb107sa6H6uJwWxc77zXoGA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.0.tgz",
+            "integrity": "sha512-JcjePYVpbezv+XOxkxPemwnorjWpgDiiKWMYy6FXTCG2rFABIK2Co1bFxIUSDT4vYO6f1448x9rKbn38vbhDiA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.19",
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0",
                 "@vercel/oidc": "3.0.5"
             },
             "engines": {
@@ -230,107 +178,30 @@
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
-        "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.19",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.19.tgz",
-            "integrity": "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==",
+        "node_modules/@ai-sdk/google": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.0.tgz",
+            "integrity": "sha512-KFS9pR7KGDyt7p1OQibglS3amoLjCXxwF7DVg+gL2RLcwFRQV0s6Tp7Q+PvGNFSqPdrPYW8mHyvn8ODK4WTImA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.6"
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/google": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.0.tgz",
-            "integrity": "sha512-35uWKG+aWm0QClJV/kNhcyR9IVrDkZoI1UlWvUCjwoqbCxj4/L/1LKKbpM3JSRa9u74ghHzBB0UjLHdgcIoanw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4"
-            }
-        },
-        "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0.tgz",
-            "integrity": "sha512-BoQZtGcBxkeSH1zK+SRYNDtJPIPpacTeiMZqnG4Rv6xXjEwM0FH4MGs9c+PlhyEWmQCzjRM2HAotEydFhD4dYw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.3",
-                "zod-to-json-schema": "^3.24.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4"
-            }
-        },
-        "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils/node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
             }
         },
         "node_modules/@ai-sdk/openai": {
-            "version": "2.0.67",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.67.tgz",
-            "integrity": "sha512-JhB3fUpY+IxAocyJt2PHuhfNwH+e+rDbZ8Q+d0hgSyNycuPRrV0xutLaf7mgDTvjr5FCrVEkXmM73tJprzZMiA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.0.tgz",
+            "integrity": "sha512-/o2xCQlRA+O0cAXIIBOfMeT35H6Fonzilz9r/IJojPOMQnmIL+0jPQVKOUPr5bouRqCjnwKpwuKEBRqm8jUZkQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.17"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/openai-compatible": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.28.tgz",
-            "integrity": "sha512-yKubDxLYtXyGUzkr9lNStf/lE/I+Okc8tmotvyABhsQHHieLKk6oV5fJeRJxhr67Ejhg+FRnwUOxAmjRoFM4dA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.18"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz",
-            "integrity": "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "eventsource-parser": "^3.0.6"
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -340,9 +211,9 @@
             }
         },
         "node_modules/@ai-sdk/provider": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-            "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0.tgz",
+            "integrity": "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-schema": "^0.4.0"
@@ -352,13 +223,13 @@
             }
         },
         "node_modules/@ai-sdk/provider-utils": {
-            "version": "3.0.18",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
-            "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.0.tgz",
+            "integrity": "sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@standard-schema/spec": "^1.0.0",
+                "@ai-sdk/provider": "3.0.0",
+                "@standard-schema/spec": "^1.1.0",
                 "eventsource-parser": "^3.0.6"
             },
             "engines": {
@@ -369,13 +240,13 @@
             }
         },
         "node_modules/@ai-sdk/react": {
-            "version": "2.0.107",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.107.tgz",
-            "integrity": "sha512-rv0u+tAi2r2zJu2uSLXcC3TBgGrkQIWXRM+i6us6qcGmYQ2kOu2VYg+lxviOSGPhL9PVebvTlN5x8mf3rDqX+w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.1.tgz",
+            "integrity": "sha512-XUPDMFgalNtqBQg+Q3UiiEmWE3PC5pAoc+Drs5Z1Mxqe57za+hKCEwViYADuqeZrc0q6PXTzbcFlQb3pjyGjcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider-utils": "3.0.18",
-                "ai": "5.0.107",
+                "@ai-sdk/provider-utils": "4.0.0",
+                "ai": "6.0.1",
                 "swr": "^2.2.5",
                 "throttleit": "2.1.0"
             },
@@ -383,13 +254,7 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "react": "^18 || ^19 || ^19.0.0-rc",
-                "zod": "^3.25.76 || ^4.1.8"
-            },
-            "peerDependenciesMeta": {
-                "zod": {
-                    "optional": true
-                }
+                "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -2182,7 +2047,7 @@
         },
         "node_modules/@electron/windows-sign": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmmirror.com/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
             "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -2204,7 +2069,7 @@
         },
         "node_modules/@electron/windows-sign/node_modules/fs-extra": {
             "version": "11.3.3",
-            "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
             "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
             "dev": true,
             "license": "MIT",
@@ -2221,7 +2086,7 @@
         },
         "node_modules/@electron/windows-sign/node_modules/jsonfile": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
             "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "dev": true,
             "license": "MIT",
@@ -2236,7 +2101,7 @@
         },
         "node_modules/@electron/windows-sign/node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
@@ -4020,12 +3885,12 @@
             }
         },
         "node_modules/@openrouter/ai-sdk-provider": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-1.2.3.tgz",
-            "integrity": "sha512-a6Nc8dPRHakRH9966YJ/HZJhLOds7DuPTscNZDoAr+Aw+tEFUlacSJMvb/b3gukn74mgbuaJRji9YOn62ipfVg==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-1.5.4.tgz",
+            "integrity": "sha512-xrSQPUIH8n9zuyYZR0XK7Ba0h2KsjJcMkxnwaYfmv13pKs3sDkjPzVPPhlhzqBGddHb5cFEwJ9VFuFeDcxCDSw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@openrouter/sdk": "^0.1.8"
+                "@openrouter/sdk": "^0.1.27"
             },
             "engines": {
                 "node": ">=18"
@@ -4036,28 +3901,12 @@
             }
         },
         "node_modules/@openrouter/sdk": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.1.11.tgz",
-            "integrity": "sha512-OuPc8qqidL/PUM8+9WgrOfSR9+b6rKIWiezGcUJ54iPTdh+Gye5Qjut6hrLWlOCMZE7Z853gN90r1ft4iChj7Q==",
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.1.27.tgz",
+            "integrity": "sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "zod": "^3.25.0 || ^4.0.0"
-            },
-            "peerDependencies": {
-                "@tanstack/react-query": "^5",
-                "react": "^18 || ^19",
-                "react-dom": "^18 || ^19"
-            },
-            "peerDependenciesMeta": {
-                "@tanstack/react-query": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -7168,9 +7017,9 @@
             }
         },
         "node_modules/@standard-schema/spec": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "license": "MIT"
         },
         "node_modules/@swc/helpers": {
@@ -8287,32 +8136,15 @@
             }
         },
         "node_modules/ai": {
-            "version": "5.0.107",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.107.tgz",
-            "integrity": "sha512-laZlS9ZC/DZfSaxPgrBqI4mM+kxRvTPBBQfa74ceBFskkunZKEsaGVFNEs4cfyGa3nCCCl1WO/fjxixp4V8Zag==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.1.tgz",
+            "integrity": "sha512-g/jPakC6h4vUJKDww0d6+VaJmfMC38UqH3kKsngiP+coT0uvCUdQ7lpFDJ0mNmamaOyRMaY2zwEB2RnTAaJU/w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "2.0.18",
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.18",
+                "@ai-sdk/gateway": "3.0.0",
+                "@ai-sdk/provider": "3.0.0",
+                "@ai-sdk/provider-utils": "4.0.0",
                 "@opentelemetry/api": "1.9.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.25.76 || ^4.1.8"
-            }
-        },
-        "node_modules/ai/node_modules/@ai-sdk/gateway": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.18.tgz",
-            "integrity": "sha512-sDQcW+6ck2m0pTIHW6BPHD7S125WD3qNkx/B8sEzJp/hurocmJ5Cni0ybExg6sQMGo+fr/GWOwpHF1cmCdg5rQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "2.0.0",
-                "@ai-sdk/provider-utils": "3.0.18",
-                "@vercel/oidc": "3.0.5"
             },
             "engines": {
                 "node": ">=18"
@@ -9791,7 +9623,7 @@
         },
         "node_modules/cross-dirname": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmmirror.com/cross-dirname/-/cross-dirname-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
             "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
             "dev": true,
             "license": "MIT",
@@ -10343,7 +10175,7 @@
         },
         "node_modules/electron-builder-squirrel-windows": {
             "version": "26.0.12",
-            "resolved": "https://registry.npmmirror.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz",
+            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz",
             "integrity": "sha512-kpwXM7c/ayRUbYVErQbsZ0nQZX4aLHQrPEG9C4h9vuJCXylwFH8a7Jgi2VpKIObzCXO7LKHiCw4KdioFLFOgqA==",
             "dev": true,
             "license": "MIT",
@@ -10456,7 +10288,7 @@
         },
         "node_modules/electron-winstaller": {
             "version": "5.4.0",
-            "resolved": "https://registry.npmmirror.com/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
             "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
             "dev": true,
             "hasInstallScript": true,
@@ -10478,7 +10310,7 @@
         },
         "node_modules/electron-winstaller/node_modules/fs-extra": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-7.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "license": "MIT",
@@ -15552,6 +15384,35 @@
                 "zod": "^4.0.16"
             }
         },
+        "node_modules/ollama-ai-provider-v2/node_modules/@ai-sdk/provider": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+            "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/ollama-ai-provider-v2/node_modules/@ai-sdk/provider-utils": {
+            "version": "3.0.19",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.19.tgz",
+            "integrity": "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "2.0.0",
+                "@standard-schema/spec": "^1.0.0",
+                "eventsource-parser": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
@@ -16040,7 +15901,7 @@
         },
         "node_modules/postject": {
             "version": "1.0.0-alpha.6",
-            "resolved": "https://registry.npmmirror.com/postject/-/postject-1.0.0-alpha.6.tgz",
+            "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
             "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
             "dev": true,
             "license": "MIT",
@@ -16058,7 +15919,7 @@
         },
         "node_modules/postject/node_modules/commander": {
             "version": "9.5.0",
-            "resolved": "https://registry.npmmirror.com/commander/-/commander-9.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
             "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
             "dev": true,
             "license": "MIT",
@@ -17872,7 +17733,7 @@
         },
         "node_modules/temp": {
             "version": "0.9.4",
-            "resolved": "https://registry.npmmirror.com/temp/-/temp-0.9.4.tgz",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
             "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
             "dev": true,
             "license": "MIT",
@@ -17936,7 +17797,7 @@
         },
         "node_modules/temp/node_modules/mkdirp": {
             "version": "0.5.6",
-            "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "license": "MIT",
@@ -17950,7 +17811,7 @@
         },
         "node_modules/temp/node_modules/rimraf": {
             "version": "2.6.3",
-            "resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-2.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,

--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
         "dist:all": "npm run electron:build && npm run electron:prepare && npx electron-builder --mac --win --linux"
     },
     "dependencies": {
-        "@ai-sdk/amazon-bedrock": "^3.0.70",
-        "@ai-sdk/anthropic": "^2.0.44",
-        "@ai-sdk/azure": "^2.0.69",
-        "@ai-sdk/deepseek": "^1.0.30",
-        "@ai-sdk/gateway": "^2.0.21",
-        "@ai-sdk/google": "^2.0.0",
-        "@ai-sdk/openai": "^2.0.19",
-        "@ai-sdk/react": "^2.0.107",
+        "@ai-sdk/amazon-bedrock": "^4.0.1",
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/azure": "^3.0.0",
+        "@ai-sdk/deepseek": "^2.0.0",
+        "@ai-sdk/gateway": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/react": "^3.0.1",
         "@aws-sdk/credential-providers": "^3.943.0",
         "@formatjs/intl-localematcher": "^0.7.2",
         "@langfuse/client": "^4.4.9",
         "@langfuse/otel": "^4.4.4",
         "@langfuse/tracing": "^4.4.9",
         "@next/third-parties": "^16.0.6",
-        "@openrouter/ai-sdk-provider": "^1.2.3",
+        "@openrouter/ai-sdk-provider": "^1.5.4",
         "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
         "@opentelemetry/sdk-trace-node": "^2.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -53,7 +53,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@xmldom/xmldom": "^0.9.8",
-        "ai": "^5.0.89",
+        "ai": "^6.0.1",
         "base-64": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -111,5 +111,10 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "wait-on": "^9.0.3"
+    },
+    "overrides": {
+        "@openrouter/ai-sdk-provider": {
+            "ai": "^6.0.1"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Upgrades AI SDK from v5.0.89 to v6.0.1
- Upgrades @ai-sdk/* provider packages to latest v3/v4
- Upgrades @openrouter/ai-sdk-provider from 1.2.3 to 1.5.4
- Adds `overrides` in package.json to resolve peer dependency conflict
- Updates `convertToModelMessages` call to async (new API in v6)
- Fixes `usage.cachedInputTokens` → `usage.inputTokenDetails?.cacheReadTokens` (new API)

## Related Issues

This upgrade may help address some provider-related issues (but does not fully resolve them):
- #245 - DeepSeek `reasoning_content` missing
- #281 - DeepSeek provider detection
- #356 - DeepSeek think model incomplete interaction
- #332 - DeepSeek configuration issues