### PR TITLE
feat: add server-side quota tracking with DynamoDB

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,6 +15,11 @@ import { z } from "zod"
 import { getAIModel, supportsPromptCaching } from "@/lib/ai-providers"
 import { findCachedResponse } from "@/lib/cached-responses"
 import {
+    checkAndIncrementRequest,
+    isQuotaEnabled,
+    recordTokenUsage,
+} from "@/lib/dynamo-quota-manager"
+import {
     getTelemetryConfig,
     setTraceInput,
     setTraceOutput,
@@ -190,6 +195,33 @@ async function handleChatRequest(req: Request): Promise<Response> {
         sessionId: validSessionId,
         userId: userId,
     })
+
+    // === SERVER-SIDE QUOTA CHECK START ===
+    // Quota is opt-in: only enabled when DYNAMODB_QUOTA_TABLE env var is set
+    const hasOwnApiKey = !!(
+        req.headers.get("x-ai-provider") && req.headers.get("x-ai-api-key")
+    )
+
+    // Skip quota check if: quota disabled, user has own API key, or is anonymous
+    if (isQuotaEnabled() && !hasOwnApiKey && userId !== "anonymous") {
+        const quotaCheck = await checkAndIncrementRequest(userId, {
+            requests: Number(process.env.DAILY_REQUEST_LIMIT) || 10,
+            tokens: Number(process.env.DAILY_TOKEN_LIMIT) || 200000,
+            tpm: Number(process.env.TPM_LIMIT) || 20000,
+        })
+        if (!quotaCheck.allowed) {
+            return Response.json(
+                {
+                    error: quotaCheck.error,
+                    type: quotaCheck.type,
+                    used: quotaCheck.used,
+                    limit: quotaCheck.limit,
+                },
+                { status: 429 },
+            )
+        }
+    }
+    // === SERVER-SIDE QUOTA CHECK END ===
 
     // === FILE VALIDATION START ===
     const fileValidation = validateFileParts(messages)
@@ -510,9 +542,21 @@ ${userInputText}
                 userId,
             }),
         }),
-        onFinish: ({ text }) => {
+        onFinish: ({ text, usage }) => {
             // AI SDK 6 telemetry auto-reports token usage on its spans
             setTraceOutput(text)
+
+            // Record token usage for server-side quota tracking (if enabled)
+            if (
+                isQuotaEnabled() &&
+                !hasOwnApiKey &&
+                userId !== "anonymous" &&
+                usage
+            ) {
+                const totalTokens =
+                    (usage.inputTokens || 0) + (usage.outputTokens || 0)
+                recordTokenUsage(userId, totalTokens)
+            }
         },
         tools: {
             // Client-side tool that will be executed on the client

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -556,6 +556,23 @@ Continue from EXACTLY where you stopped.`,
             }
         },
         onError: (error) => {
+            // Handle server-side quota limit (429 response)
+            if (error.message.includes("Daily request limit")) {
+                quotaManager.showQuotaLimitToast()
+                return
+            }
+            if (error.message.includes("Daily token limit")) {
+                quotaManager.showTokenLimitToast(dailyTokenLimit)
+                return
+            }
+            if (
+                error.message.includes("Rate limit exceeded") ||
+                error.message.includes("tokens per minute")
+            ) {
+                quotaManager.showTPMLimitToast()
+                return
+            }
+
             // Silence access code error in console since it's handled by UI
             if (!error.message.includes("Invalid or missing access code")) {
                 console.error("Chat error:", error)
@@ -632,16 +649,6 @@ Continue from EXACTLY where you stopped.`,
 
             // DEBUG: Log finish reason to diagnose truncation
             console.log("[onFinish] finishReason:", metadata?.finishReason)
-
-            // AI SDK 6 provides totalTokens directly
-            const totalTokens =
-                metadata && Number.isFinite(metadata.totalTokens)
-                    ? (metadata.totalTokens as number)
-                    : 0
-            if (totalTokens > 0) {
-                quotaManager.incrementTokenCount(totalTokens)
-                quotaManager.incrementTPMCount(totalTokens)
-            }
         },
         sendAutomaticallyWhen: ({ messages }) => {
             const isInContinuationMode = partialXmlRef.current.length > 0
@@ -684,25 +691,6 @@ Continue from EXACTLY where you stopped.`,
                 }
                 // Increment retry count for actual errors
                 autoRetryCountRef.current++
-            }
-
-            // Check quota limits before auto-retry
-            const tokenLimitCheck = quotaManager.checkTokenLimit()
-            if (!tokenLimitCheck.allowed) {
-                quotaManager.showTokenLimitToast(tokenLimitCheck.used)
-                autoRetryCountRef.current = 0
-                continuationRetryCountRef.current = 0
-                partialXmlRef.current = ""
-                return false
-            }
-
-            const tpmCheck = quotaManager.checkTPMLimit()
-            if (!tpmCheck.allowed) {
-                quotaManager.showTPMLimitToast()
-                autoRetryCountRef.current = 0
-                continuationRetryCountRef.current = 0
-                partialXmlRef.current = ""
-                return false
             }
 
             return true
@@ -921,9 +909,6 @@ Continue from EXACTLY where you stopped.`,
                 xmlSnapshotsRef.current.set(messageIndex, chartXml)
                 saveXmlSnapshots()
 
-                // Check all quota limits
-                if (!checkAllQuotaLimits()) return
-
                 sendChatMessage(parts, chartXml, previousXml, sessionId)
 
                 // Token count is tracked in onFinish with actual server usage
@@ -1001,30 +986,7 @@ Continue from EXACTLY where you stopped.`,
         saveXmlSnapshots()
     }
 
-    // Check all quota limits (daily requests, tokens, TPM)
-    const checkAllQuotaLimits = (): boolean => {
-        const limitCheck = quotaManager.checkDailyLimit()
-        if (!limitCheck.allowed) {
-            quotaManager.showQuotaLimitToast()
-            return false
-        }
-
-        const tokenLimitCheck = quotaManager.checkTokenLimit()
-        if (!tokenLimitCheck.allowed) {
-            quotaManager.showTokenLimitToast(tokenLimitCheck.used)
-            return false
-        }
-
-        const tpmCheck = quotaManager.checkTPMLimit()
-        if (!tpmCheck.allowed) {
-            quotaManager.showTPMLimitToast()
-            return false
-        }
-
-        return true
-    }
-
-    // Send chat message with headers and increment quota
+    // Send chat message with headers
     const sendChatMessage = (
         parts: any,
         xml: string,
@@ -1074,7 +1036,6 @@ Continue from EXACTLY where you stopped.`,
                 },
             },
         )
-        quotaManager.incrementRequestCount()
     }
 
     // Process files and append content to user text (handles PDF, text, and optionally images)
@@ -1162,13 +1123,8 @@ Continue from EXACTLY where you stopped.`,
             setMessages(newMessages)
         })
 
-        // Check all quota limits
-        if (!checkAllQuotaLimits()) return
-
         // Now send the message after state is guaranteed to be updated
         sendChatMessage(userParts, savedXml, previousXml, sessionId)
-
-        // Token count is tracked in onFinish with actual server usage
     }
 
     const handleEditMessage = async (messageIndex: number, newText: string) => {
@@ -1210,12 +1166,8 @@ Continue from EXACTLY where you stopped.`,
             setMessages(newMessages)
         })
 
-        // Check all quota limits
-        if (!checkAllQuotaLimits()) return
-
         // Now send the edited message after state is guaranteed to be updated
         sendChatMessage(newParts, savedXml, previousXml, sessionId)
-        // Token count is tracked in onFinish with actual server usage
     }
 
     // Collapsed view (desktop only)

--- a/lib/dynamo-quota-manager.ts
+++ b/lib/dynamo-quota-manager.ts
@@ -1,0 +1,238 @@
+import {
+    ConditionalCheckFailedException,
+    DynamoDBClient,
+    GetItemCommand,
+    UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb"
+
+// Quota tracking is OPT-IN: only enabled if DYNAMODB_QUOTA_TABLE is explicitly set
+// OSS users who don't need quota tracking can simply not set this env var
+const TABLE = process.env.DYNAMODB_QUOTA_TABLE
+const DYNAMODB_REGION = process.env.DYNAMODB_REGION || "ap-northeast-1"
+
+// Only create client if quota is enabled
+const client = TABLE ? new DynamoDBClient({ region: DYNAMODB_REGION }) : null
+
+/**
+ * Check if server-side quota tracking is enabled.
+ * Quota is opt-in: only enabled when DYNAMODB_QUOTA_TABLE env var is set.
+ */
+export function isQuotaEnabled(): boolean {
+    return !!TABLE
+}
+
+interface QuotaLimits {
+    requests: number // Daily request limit
+    tokens: number // Daily token limit
+    tpm: number // Tokens per minute
+}
+
+interface QuotaCheckResult {
+    allowed: boolean
+    error?: string
+    type?: "request" | "token" | "tpm"
+    used?: number
+    limit?: number
+}
+
+/**
+ * Check all quotas and increment request count atomically.
+ * Uses ConditionExpression to prevent race conditions.
+ * Returns which limit was exceeded if any.
+ */
+export async function checkAndIncrementRequest(
+    ip: string,
+    limits: QuotaLimits,
+): Promise<QuotaCheckResult> {
+    // Skip if quota tracking not enabled
+    if (!client || !TABLE) {
+        return { allowed: true }
+    }
+
+    const today = new Date().toISOString().split("T")[0]
+    const currentMinute = Math.floor(Date.now() / 60000).toString()
+    const ttl = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+
+    try {
+        // Atomic check-and-increment with ConditionExpression
+        // This prevents race conditions by failing if limits are exceeded
+        await client.send(
+            new UpdateItemCommand({
+                TableName: TABLE,
+                Key: { PK: { S: `IP#${ip}` } },
+                // Reset counts if new day/minute, then increment request count
+                UpdateExpression: `
+                    SET lastResetDate = :today,
+                        dailyReqCount = if_not_exists(dailyReqCount, :zero) + :one,
+                        dailyTokenCount = if_not_exists(dailyTokenCount, :zero),
+                        lastMinute = :minute,
+                        tpmCount = if_not_exists(tpmCount, :zero),
+                        #ttl = :ttl
+                `,
+                // Atomic condition: only succeed if ALL limits pass
+                // Uses attribute_not_exists for new items, then checks limits for existing items
+                ConditionExpression: `
+                    (attribute_not_exists(lastResetDate) OR lastResetDate < :today OR
+                     ((attribute_not_exists(dailyReqCount) OR dailyReqCount < :reqLimit) AND
+                      (attribute_not_exists(dailyTokenCount) OR dailyTokenCount < :tokenLimit))) AND
+                    (attribute_not_exists(lastMinute) OR lastMinute <> :minute OR
+                     attribute_not_exists(tpmCount) OR tpmCount < :tpmLimit)
+                `,
+                ExpressionAttributeNames: { "#ttl": "ttl" },
+                ExpressionAttributeValues: {
+                    ":today": { S: today },
+                    ":zero": { N: "0" },
+                    ":one": { N: "1" },
+                    ":minute": { S: currentMinute },
+                    ":ttl": { N: String(ttl) },
+                    ":reqLimit": { N: String(limits.requests || 999999) },
+                    ":tokenLimit": { N: String(limits.tokens || 999999) },
+                    ":tpmLimit": { N: String(limits.tpm || 999999) },
+                },
+            }),
+        )
+
+        return { allowed: true }
+    } catch (e: any) {
+        // Condition failed - need to determine which limit was exceeded
+        if (e instanceof ConditionalCheckFailedException) {
+            // Get current counts to determine which limit was hit
+            try {
+                const getResult = await client.send(
+                    new GetItemCommand({
+                        TableName: TABLE,
+                        Key: { PK: { S: `IP#${ip}` } },
+                    }),
+                )
+
+                const item = getResult.Item
+                const storedDate = item?.lastResetDate?.S
+                const storedMinute = item?.lastMinute?.S
+                const isNewDay = !storedDate || storedDate < today
+
+                const dailyReqCount = isNewDay
+                    ? 0
+                    : Number(item?.dailyReqCount?.N || 0)
+                const dailyTokenCount = isNewDay
+                    ? 0
+                    : Number(item?.dailyTokenCount?.N || 0)
+                const tpmCount =
+                    storedMinute !== currentMinute
+                        ? 0
+                        : Number(item?.tpmCount?.N || 0)
+
+                // Determine which limit was exceeded
+                if (limits.requests > 0 && dailyReqCount >= limits.requests) {
+                    return {
+                        allowed: false,
+                        type: "request",
+                        error: "Daily request limit exceeded",
+                        used: dailyReqCount,
+                        limit: limits.requests,
+                    }
+                }
+                if (limits.tokens > 0 && dailyTokenCount >= limits.tokens) {
+                    return {
+                        allowed: false,
+                        type: "token",
+                        error: "Daily token limit exceeded",
+                        used: dailyTokenCount,
+                        limit: limits.tokens,
+                    }
+                }
+                if (limits.tpm > 0 && tpmCount >= limits.tpm) {
+                    return {
+                        allowed: false,
+                        type: "tpm",
+                        error: "Rate limit exceeded (tokens per minute)",
+                        used: tpmCount,
+                        limit: limits.tpm,
+                    }
+                }
+
+                // Condition failed but no limit clearly exceeded - race condition edge case
+                // Fail safe by allowing (could be a reset race)
+                console.warn(
+                    `[quota] Condition failed but no limit exceeded for IP prefix: ${ip.slice(0, 8)}...`,
+                )
+                return { allowed: true }
+            } catch (getError: any) {
+                console.error(
+                    `[quota] Failed to get quota details after condition failure, IP prefix: ${ip.slice(0, 8)}..., error: ${getError.message}`,
+                )
+                return { allowed: true } // Fail open
+            }
+        }
+
+        // Other DynamoDB errors - fail open
+        console.error(
+            `[quota] DynamoDB error (fail-open), IP prefix: ${ip.slice(0, 8)}..., error: ${e.message}`,
+        )
+        return { allowed: true }
+    }
+}
+
+/**
+ * Record token usage after response completes.
+ * Uses atomic operations to update both daily token count and TPM count.
+ * Handles minute boundaries atomically to prevent race conditions.
+ */
+export async function recordTokenUsage(
+    ip: string,
+    tokens: number,
+): Promise<void> {
+    // Skip if quota tracking not enabled
+    if (!client || !TABLE) return
+    if (!Number.isFinite(tokens) || tokens <= 0) return
+
+    const currentMinute = Math.floor(Date.now() / 60000).toString()
+    const ttl = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+
+    try {
+        // Try to update assuming same minute (most common case)
+        // Uses condition to ensure we're in the same minute
+        await client.send(
+            new UpdateItemCommand({
+                TableName: TABLE,
+                Key: { PK: { S: `IP#${ip}` } },
+                UpdateExpression:
+                    "SET #ttl = :ttl ADD dailyTokenCount :tokens, tpmCount :tokens",
+                ConditionExpression: "lastMinute = :minute",
+                ExpressionAttributeNames: { "#ttl": "ttl" },
+                ExpressionAttributeValues: {
+                    ":minute": { S: currentMinute },
+                    ":tokens": { N: String(tokens) },
+                    ":ttl": { N: String(ttl) },
+                },
+            }),
+        )
+    } catch (e: any) {
+        if (e instanceof ConditionalCheckFailedException) {
+            // Different minute - reset TPM count and set new minute
+            try {
+                await client.send(
+                    new UpdateItemCommand({
+                        TableName: TABLE,
+                        Key: { PK: { S: `IP#${ip}` } },
+                        UpdateExpression:
+                            "SET lastMinute = :minute, tpmCount = :tokens, #ttl = :ttl ADD dailyTokenCount :tokens",
+                        ExpressionAttributeNames: { "#ttl": "ttl" },
+                        ExpressionAttributeValues: {
+                            ":minute": { S: currentMinute },
+                            ":tokens": { N: String(tokens) },
+                            ":ttl": { N: String(ttl) },
+                        },
+                    }),
+                )
+            } catch (retryError: any) {
+                console.error(
+                    `[quota] Failed to record tokens (retry), IP prefix: ${ip.slice(0, 8)}..., tokens: ${tokens}, error: ${retryError.message}`,
+                )
+            }
+        } else {
+            console.error(
+                `[quota] Failed to record tokens, IP prefix: ${ip.slice(0, 8)}..., tokens: ${tokens}, error: ${e.message}`,
+            )
+        }
+    }
+}

--- a/lib/use-quota-manager.tsx
+++ b/lib/use-quota-manager.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { useCallback, useMemo } from "react"
+import { useCallback } from "react"
 import { toast } from "sonner"
 import { QuotaLimitToast } from "@/components/quota-limit-toast"
 import { useDictionary } from "@/hooks/use-dictionary"
 import { formatMessage } from "@/lib/i18n/utils"
-import { STORAGE_KEYS } from "@/lib/storage"
 
 export interface QuotaConfig {
     dailyRequestLimit: number
@@ -13,133 +12,18 @@ export interface QuotaConfig {
     tpmLimit: number
 }
 
-export interface QuotaCheckResult {
-    allowed: boolean
-    remaining: number
-    used: number
-}
-
 /**
- * Hook for managing request/token quotas and rate limiting.
- * Handles three types of limits:
- * - Daily request limit
- * - Daily token limit
- * - Tokens per minute (TPM) rate limit
- *
- * Users with their own API key bypass all limits.
+ * Hook for displaying quota limit toasts.
+ * Server-side handles actual quota enforcement via DynamoDB.
+ * This hook only provides UI feedback when limits are exceeded.
  */
 export function useQuotaManager(config: QuotaConfig): {
-    hasOwnApiKey: () => boolean
-    checkDailyLimit: () => QuotaCheckResult
-    checkTokenLimit: () => QuotaCheckResult
-    checkTPMLimit: () => QuotaCheckResult
-    incrementRequestCount: () => void
-    incrementTokenCount: (tokens: number) => void
-    incrementTPMCount: (tokens: number) => void
     showQuotaLimitToast: () => void
     showTokenLimitToast: (used: number) => void
     showTPMLimitToast: () => void
 } {
     const { dailyRequestLimit, dailyTokenLimit, tpmLimit } = config
-
     const dict = useDictionary()
-
-    // Check if user has their own API key configured (bypass limits)
-    const hasOwnApiKey = useCallback((): boolean => {
-        const provider = localStorage.getItem(STORAGE_KEYS.aiProvider)
-        const apiKey = localStorage.getItem(STORAGE_KEYS.aiApiKey)
-        return !!(provider && apiKey)
-    }, [])
-
-    // Generic helper: Parse count from localStorage with NaN guard
-    const parseStorageCount = (key: string): number => {
-        const count = parseInt(localStorage.getItem(key) || "0", 10)
-        return Number.isNaN(count) ? 0 : count
-    }
-
-    // Generic helper: Create quota checker factory
-    const createQuotaChecker = useCallback(
-        (
-            getTimeKey: () => string,
-            timeStorageKey: string,
-            countStorageKey: string,
-            limit: number,
-        ) => {
-            return (): QuotaCheckResult => {
-                if (hasOwnApiKey())
-                    return { allowed: true, remaining: -1, used: 0 }
-                if (limit <= 0) return { allowed: true, remaining: -1, used: 0 }
-
-                const currentTime = getTimeKey()
-                const storedTime = localStorage.getItem(timeStorageKey)
-                let count = parseStorageCount(countStorageKey)
-
-                if (storedTime !== currentTime) {
-                    count = 0
-                    localStorage.setItem(timeStorageKey, currentTime)
-                    localStorage.setItem(countStorageKey, "0")
-                }
-
-                return {
-                    allowed: count < limit,
-                    remaining: limit - count,
-                    used: count,
-                }
-            }
-        },
-        [hasOwnApiKey],
-    )
-
-    // Generic helper: Create quota incrementer factory
-    const createQuotaIncrementer = useCallback(
-        (
-            getTimeKey: () => string,
-            timeStorageKey: string,
-            countStorageKey: string,
-            validateInput: boolean = false,
-        ) => {
-            return (tokens: number = 1): void => {
-                if (validateInput && (!Number.isFinite(tokens) || tokens <= 0))
-                    return
-
-                const currentTime = getTimeKey()
-                const storedTime = localStorage.getItem(timeStorageKey)
-                let count = parseStorageCount(countStorageKey)
-
-                if (storedTime !== currentTime) {
-                    count = 0
-                    localStorage.setItem(timeStorageKey, currentTime)
-                }
-
-                localStorage.setItem(countStorageKey, String(count + tokens))
-            }
-        },
-        [],
-    )
-
-    // Check daily request limit
-    const checkDailyLimit = useMemo(
-        () =>
-            createQuotaChecker(
-                () => new Date().toDateString(),
-                STORAGE_KEYS.requestDate,
-                STORAGE_KEYS.requestCount,
-                dailyRequestLimit,
-            ),
-        [createQuotaChecker, dailyRequestLimit],
-    )
-
-    // Increment request count
-    const incrementRequestCount = useMemo(
-        () =>
-            createQuotaIncrementer(
-                () => new Date().toDateString(),
-                STORAGE_KEYS.requestDate,
-                STORAGE_KEYS.requestCount,
-                false,
-            ),
-        [createQuotaIncrementer],
-    )
 
     // Show quota limit toast (request-based)
     const showQuotaLimitToast = useCallback(() => {
@@ -154,30 +38,6 @@ export function useQuotaManager(config: QuotaConfig): {
             { duration: 15000 },
         )
     }, [dailyRequestLimit])
-
-    // Check daily token limit
-    const checkTokenLimit = useMemo(
-        () =>
-            createQuotaChecker(
-                () => new Date().toDateString(),
-                STORAGE_KEYS.tokenDate,
-                STORAGE_KEYS.tokenCount,
-                dailyTokenLimit,
-            ),
-        [createQuotaChecker, dailyTokenLimit],
-    )
-
-    // Increment token count
-    const incrementTokenCount = useMemo(
-        () =>
-            createQuotaIncrementer(
-                () => new Date().toDateString(),
-                STORAGE_KEYS.tokenDate,
-                STORAGE_KEYS.tokenCount,
-                true, // Validate input tokens
-            ),
-        [createQuotaIncrementer],
-    )
 
     // Show token limit toast
     const showTokenLimitToast = useCallback(
@@ -197,30 +57,6 @@ export function useQuotaManager(config: QuotaConfig): {
         [dailyTokenLimit],
     )
 
-    // Check TPM (tokens per minute) limit
-    const checkTPMLimit = useMemo(
-        () =>
-            createQuotaChecker(
-                () => Math.floor(Date.now() / 60000).toString(),
-                STORAGE_KEYS.tpmMinute,
-                STORAGE_KEYS.tpmCount,
-                tpmLimit,
-            ),
-        [createQuotaChecker, tpmLimit],
-    )
-
-    // Increment TPM count
-    const incrementTPMCount = useMemo(
-        () =>
-            createQuotaIncrementer(
-                () => Math.floor(Date.now() / 60000).toString(),
-                STORAGE_KEYS.tpmMinute,
-                STORAGE_KEYS.tpmCount,
-                true, // Validate input tokens
-            ),
-        [createQuotaIncrementer],
-    )
-
     // Show TPM limit toast
     const showTPMLimitToast = useCallback(() => {
         const limitDisplay =
@@ -233,18 +69,6 @@ export function useQuotaManager(config: QuotaConfig): {
     }, [tpmLimit, dict])
 
     return {
-        // Check functions
-        hasOwnApiKey,
-        checkDailyLimit,
-        checkTokenLimit,
-        checkTPMLimit,
-
-        // Increment functions
-        incrementRequestCount,
-        incrementTokenCount,
-        incrementTPMCount,
-
-        // Toast functions
         showQuotaLimitToast,
         showTokenLimitToast,
         showTPMLimitToast,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "@ai-sdk/google": "^3.0.0",
                 "@ai-sdk/openai": "^3.0.0",
                 "@ai-sdk/react": "^3.0.1",
+                "@aws-sdk/client-dynamodb": "^3.957.0",
                 "@aws-sdk/credential-providers": "^3.943.0",
                 "@formatjs/intl-localematcher": "^0.7.2",
                 "@langfuse/client": "^4.4.9",
@@ -500,6 +501,515 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-dynamodb": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.957.0.tgz",
+            "integrity": "sha512-H/uHYgZTmFUq2qb4b/GTxT2F8Yyqyb3pMpI3mldGINZkPYQYN9pP246pqnf+OYOClPMxSMRchrbjZgZhADMi8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/credential-provider-node": "3.957.0",
+                "@aws-sdk/dynamodb-codec": "3.957.0",
+                "@aws-sdk/middleware-endpoint-discovery": "3.957.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-waiter": "^4.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.957.0.tgz",
+            "integrity": "sha512-iRdRjd+IpOogqRPt8iNRcg30J53z4rRfMviGwpKgsEa/fx3inCUPOuca3Ap7ZDES0atnEg3KGSJ3V/NQiEJ4BA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/core": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.957.0.tgz",
+            "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/xml-builder": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/signature-v4": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.957.0.tgz",
+            "integrity": "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.957.0.tgz",
+            "integrity": "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-stream": "^4.5.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.957.0.tgz",
+            "integrity": "sha512-YuoZmIeE91YIeUfihh8SiSu546KtTvU+4rG5SaL30U9+nGq6P11GRRgqF0ANUyRseLC9ONHt+utar4gbO3++og==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/credential-provider-env": "3.957.0",
+                "@aws-sdk/credential-provider-http": "3.957.0",
+                "@aws-sdk/credential-provider-login": "3.957.0",
+                "@aws-sdk/credential-provider-process": "3.957.0",
+                "@aws-sdk/credential-provider-sso": "3.957.0",
+                "@aws-sdk/credential-provider-web-identity": "3.957.0",
+                "@aws-sdk/nested-clients": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.957.0.tgz",
+            "integrity": "sha512-XcD5NEQDWYk8B4gs89bkwf2d+DNF8oS2NR5RoHJEbX4l8KErVATUjpEYVn6/rAFEktungxlYTnQ5wh0cIQvP5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.957.0.tgz",
+            "integrity": "sha512-b9FT/7BQcJ001w+3JbTiJXfxHrWvPb7zDvvC1i1FKcNOvyCt3BGu04n4nO/b71a3iBnbfBXI89hCIZQsuLcEgw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.957.0",
+                "@aws-sdk/credential-provider-http": "3.957.0",
+                "@aws-sdk/credential-provider-ini": "3.957.0",
+                "@aws-sdk/credential-provider-process": "3.957.0",
+                "@aws-sdk/credential-provider-sso": "3.957.0",
+                "@aws-sdk/credential-provider-web-identity": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.957.0.tgz",
+            "integrity": "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.957.0.tgz",
+            "integrity": "sha512-gTLPJFOkGtn3tVGglRhCar2oOobK1YctZRAT8nfJr17uaSRoAP46zIIHNYBZZUMqImb0qAHD9Ugm+Zd9sIqxyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.957.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/token-providers": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.957.0.tgz",
+            "integrity": "sha512-x17xMeD7c+rKEsWachGIMifACqkugskrETWz18QDWismFcrmUuOcZu5rUa8s9y1pnITLKUQ1xU/qDLPH52jLlA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
+            "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
+            "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
+            "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.957.0.tgz",
+            "integrity": "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.957.0.tgz",
+            "integrity": "sha512-PZUFtaUTSZWO+mbgQGWSiwz3EqedsuKNb7Xoxjzh5rfJE352DD4/jScQEhVPxvdLw62IK9b5UDu5kZlxzBs9Ow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
+            "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.957.0.tgz",
+            "integrity": "sha512-oSwo3BZ6gcvhjTg036V0UQmtENUeNwfCU35iDckX961CdI1alQ3TKRWLzKrwvXCbrOx+bZsuA1PHsTbNhI/+Fw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.957.0.tgz",
+            "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
+            "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-endpoints": "^3.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
+            "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.957.0.tgz",
+            "integrity": "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+            "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-sso": {
             "version": "3.943.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.943.0.tgz",
@@ -772,6 +1282,120 @@
                 "@smithy/node-config-provider": "^4.3.5",
                 "@smithy/property-provider": "^4.2.5",
                 "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/dynamodb-codec": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.957.0.tgz",
+            "integrity": "sha512-xds1mkwEGzXrNy/gT6/ehaJ+cbYn/QM7AkdwNrO1NBlwJVLo3imO6hOnOQ/0KWG2ck1dbKv9H9f2hka67bAzEA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-dynamodb": "^3.957.0"
+            }
+        },
+        "node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/core": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.957.0.tgz",
+            "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/xml-builder": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/signature-v4": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/types": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.957.0.tgz",
+            "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/dynamodb-codec/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+            "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/endpoint-cache": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.957.0.tgz",
+            "integrity": "sha512-QxvFejXYYBZp/GBfT7B15gvmvuq+0f2U8RPHqArf5IqBi51ZyBqUD805tQ8TlsVrlLoi+Z4fEFw4HEM5pGvPUg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "mnemonist": "0.38.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.957.0.tgz",
+            "integrity": "sha512-MJjlw4mVJNTyR5dW6wpzKLRzFPIYAMA8qUWqgG4hGscmm4GFHvWVJ9mhhdpDu7Ie4Uaikmzfy0C4xzZ+lkf1+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/endpoint-cache": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+            "version": "3.957.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.957.0.tgz",
+            "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6422,12 +7046,12 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-            "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+            "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6435,16 +7059,16 @@
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-            "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+            "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-config-provider": "^4.2.0",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6452,18 +7076,18 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.18.7",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
-            "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.0.tgz",
+            "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-stream": "^4.5.8",
                 "@smithy/util-utf8": "^4.2.0",
                 "@smithy/uuid": "^1.1.0",
                 "tslib": "^2.6.2"
@@ -6473,15 +7097,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-            "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+            "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6504,14 +7128,14 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-            "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+            "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/querystring-builder": "^4.2.7",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-base64": "^4.3.0",
                 "tslib": "^2.6.2"
             },
@@ -6520,12 +7144,12 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-            "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+            "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-buffer-from": "^4.2.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
@@ -6535,12 +7159,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-            "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+            "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6560,13 +7184,13 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-            "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+            "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6574,18 +7198,18 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.3.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
-            "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
+            "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-middleware": "^4.2.7",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6593,18 +7217,18 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
-            "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
+            "version": "4.4.17",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
+            "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/service-error-classification": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
                 "@smithy/uuid": "^1.1.0",
                 "tslib": "^2.6.2"
             },
@@ -6613,13 +7237,13 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-            "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+            "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6627,12 +7251,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-            "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+            "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6640,14 +7264,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-            "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+            "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6655,15 +7279,15 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-            "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+            "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/abort-controller": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/querystring-builder": "^4.2.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6671,12 +7295,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-            "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+            "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6684,12 +7308,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-            "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+            "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6697,12 +7321,12 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-            "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+            "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-uri-escape": "^4.2.0",
                 "tslib": "^2.6.2"
             },
@@ -6711,12 +7335,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-            "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+            "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6724,24 +7348,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-            "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+            "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0"
+                "@smithy/types": "^4.11.0"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-            "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+            "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6749,16 +7373,16 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-            "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+            "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-uri-escape": "^4.2.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
@@ -6768,17 +7392,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.9.10",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
-            "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
+            "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
+                "@smithy/core": "^3.20.0",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-stream": "^4.5.8",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6786,9 +7410,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-            "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
+            "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -6798,13 +7422,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-            "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+            "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/querystring-parser": "^4.2.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6875,14 +7499,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.13",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
-            "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
+            "version": "4.3.16",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
+            "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6890,17 +7514,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.16",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
-            "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
+            "version": "4.2.19",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
+            "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6908,13 +7532,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-            "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+            "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6934,12 +7558,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-            "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+            "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6947,13 +7571,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-            "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+            "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/service-error-classification": "^4.2.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6961,14 +7585,14 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-            "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+            "version": "4.5.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+            "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/types": "^4.11.0",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-buffer-from": "^4.2.0",
                 "@smithy/util-hex-encoding": "^4.2.0",
@@ -6998,6 +7622,20 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+            "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.7",
+                "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -14943,6 +15581,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/mnemonist": {
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+            "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+            "license": "MIT",
+            "dependencies": {
+                "obliterator": "^1.6.1"
+            }
+        },
         "node_modules/motion": {
             "version": "12.23.25",
             "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.25.tgz",
@@ -15367,6 +16014,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/obliterator": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+            "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+            "license": "MIT"
         },
         "node_modules/ollama-ai-provider-v2": {
             "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.1",
+        "@aws-sdk/client-dynamodb": "^3.957.0",
         "@aws-sdk/credential-providers": "^3.943.0",
         "@formatjs/intl-localematcher": "^0.7.2",
         "@langfuse/client": "^4.4.9",


### PR DESCRIPTION
## Summary

Replaces client-side quota enforcement (localStorage-based, bypassable) with server-side enforcement using DynamoDB.

- Enforces daily request limit, daily token limit, and TPM (tokens per minute)
- Returns 429 with quota details when exceeded
- Uses atomic ConditionExpression to prevent race conditions
- **Opt-in**: Only enabled when `DYNAMODB_QUOTA_TABLE` env var is set
- OSS users don't need any configuration (quota disabled by default)

## Changes

- Add `lib/dynamo-quota-manager.ts` for atomic quota checks
- Simplify `lib/use-quota-manager.tsx` to only display toasts
- Update `app/api/chat/route.ts` to check quota on requests
- Add `@aws-sdk/client-dynamodb` dependency