### PR TITLE
fix: use totalUsage with cachedInputTokens for accurate quota tracking

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -542,19 +542,24 @@ ${userInputText}
                 userId,
             }),
         }),
-        onFinish: ({ text, usage }) => {
+        onFinish: ({ text, totalUsage }) => {
             // AI SDK 6 telemetry auto-reports token usage on its spans
             setTraceOutput(text)
 
             // Record token usage for server-side quota tracking (if enabled)
+            // Use totalUsage (cumulative across all steps) instead of usage (final step only)
+            // Include all 4 token types: input, output, cache read, cache write
             if (
                 isQuotaEnabled() &&
                 !hasOwnApiKey &&
                 userId !== "anonymous" &&
-                usage
+                totalUsage
             ) {
                 const totalTokens =
-                    (usage.inputTokens || 0) + (usage.outputTokens || 0)
+                    (totalUsage.inputTokens || 0) +
+                    (totalUsage.outputTokens || 0) +
+                    (totalUsage.cachedInputTokens || 0) +
+                    (totalUsage.inputTokenDetails?.cacheWriteTokens || 0)
                 recordTokenUsage(userId, totalTokens)
             }
         },


### PR DESCRIPTION
## Summary

Fixes token counting in DynamoDB quota tracking which was underreporting by ~10x.

**Root cause:** Two issues in `onFinish` callback:
1. Used `usage` (final step only) instead of `totalUsage` (cumulative across all steps)
2. `inputTokens` excludes cached tokens from prompt caching

**Before:** ~400 tokens recorded per request
**After:** ~7,000 tokens recorded (matches Langfuse totals)

## Changes

- Changed from `usage` to `totalUsage` for multi-step tool call support
- Added `cachedInputTokens` to total since prompt caching excludes them from `inputTokens`

## Testing

Tested locally with quota tracking enabled:
- Langfuse reported: 7,011 tokens
- DynamoDB recorded: 7,011 tokens ✓