### PR TITLE
fix: remove unused partialXmlRef prop from ChatMessageDisplay

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1431,7 +1431,6 @@ Continue from EXACTLY where you stopped.`,
                     setFiles={handleFileChange}
                     processedToolCallsRef={processedToolCallsRef}
                     editDiagramOriginalXmlRef={editDiagramOriginalXmlRef}
-                    partialXmlRef={partialXmlRef}
                     sessionId={sessionId}
                     onRegenerate={handleRegenerate}
                     status={status}


### PR DESCRIPTION
## Summary

Removes unused `partialXmlRef` prop that was being passed to `ChatMessageDisplay` but not used by that component (not in its props interface, not used in the component body).

This was causing a TypeScript build error.