### PR TITLE
fix: filter Langfuse traces to only export chat and AI SDK spans

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -14,22 +14,14 @@ export function register() {
         publicKey: process.env.LANGFUSE_PUBLIC_KEY,
         secretKey: process.env.LANGFUSE_SECRET_KEY,
         baseUrl: process.env.LANGFUSE_BASEURL,
-        // Filter out Next.js HTTP request spans so AI SDK spans become root traces
+        // Whitelist approach: only export AI-related spans
         shouldExportSpan: ({ otelSpan }) => {
             const spanName = otelSpan.name
-            // Skip Next.js HTTP infrastructure spans
-            if (
-                spanName.startsWith("POST") ||
-                spanName.startsWith("GET") ||
-                spanName.startsWith("RSC") ||
-                spanName.includes("BaseServer") ||
-                spanName.includes("handleRequest") ||
-                spanName.includes("resolve page") ||
-                spanName.includes("start response")
-            ) {
-                return false
+            // Only export AI SDK spans (ai.*) and our explicit "chat" wrapper
+            if (spanName === "chat" || spanName.startsWith("ai.")) {
+                return true
             }
-            return true
+            return false
         },
     })
 


### PR DESCRIPTION
## Summary

- Switch from blocklist to whitelist approach for Langfuse span filtering
- Only export spans named `chat` or starting with `ai.` (AI SDK spans)
- Filters out Next.js infrastructure noise (HEAD, fetch, POST requests)

## Problem

Langfuse was recording 74K+ traces, but only 6K were actual chat traces. The rest were:
- HEAD requests
- HEAD /[lang] requests
- fetch GET https://registry.np... spans
- POST requests (Next.js infrastructure)

## Solution

Changed `shouldExportSpan` in `instrumentation.ts` from a blocklist approach (trying to exclude known bad spans) to a whitelist approach (only include known good spans).

Intentional traces are preserved:
- ✅ `chat` - whitelisted in OTel filter
- ✅ `ai.*` - whitelisted in OTel filter (ai.streamText, ai.toolCall, etc.)
- ✅ `user-feedback` - uses direct Langfuse API, bypasses OTel filter entirely