### PR TITLE
Add deprecation notice to Electron settings panel

### DIFF
--- a/electron/settings/index.html
+++ b/electron/settings/index.html
@@ -9,6 +9,12 @@
 </head>
 <body>
     <div class="container">
+        <div class="deprecation-notice">
+            <strong>⚠️ Deprecation Notice</strong>
+            <p>This settings panel will be removed in a future update.</p>
+            <p>Please use the <strong>AI Model Configuration</strong> button (left of the Send button in the chat panel) to configure your AI providers. Your settings there will persist across updates.</p>
+        </div>
+
         <h1>Configuration Presets</h1>
 
         <div class="section">

--- a/electron/settings/settings.css
+++ b/electron/settings/settings.css
@@ -24,6 +24,39 @@
     }
 }
 
+.deprecation-notice {
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 20px;
+}
+
+.deprecation-notice strong {
+    color: #856404;
+    display: block;
+    margin-bottom: 8px;
+    font-size: 14px;
+}
+
+.deprecation-notice p {
+    color: #856404;
+    font-size: 13px;
+    margin: 4px 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    .deprecation-notice {
+        background-color: #332701;
+        border-color: #665200;
+    }
+
+    .deprecation-notice strong,
+    .deprecation-notice p {
+        color: #ffc107;
+    }
+}
+
 * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## Summary

- Add deprecation warning banner to Electron settings window
- Notify users to migrate to the AI Model Configuration button in the chat panel
- Supports both light and dark mode styling

This prepares users for the eventual removal of the Electron settings panel in a future release.

## Screenshot

The settings window now shows a warning at the top directing users to use the new model configuration UI.