### PR TITLE
fix: reset test button to idle state when switching providers

### DIFF
--- a/components/model-config-dialog.tsx
+++ b/components/model-config-dialog.tsx
@@ -412,11 +412,7 @@ export function ModelConfigDialog({
                                                 setSelectedProviderId(
                                                     provider.id,
                                                 )
-                                                setValidationStatus(
-                                                    provider.validated
-                                                        ? "success"
-                                                        : "idle",
-                                                )
+                                                setValidationStatus("idle")
                                                 setShowApiKey(false)
                                             }}
                                             className={cn(

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -83,22 +83,24 @@ export const PROVIDER_INFO: Record<
 // Suggested models per provider for quick add
 export const SUGGESTED_MODELS: Record<ProviderName, string[]> = {
     openai: [
-        // GPT-4o series (latest)
+        "gpt-5.2-pro",
+        "gpt-5.2-chat-latest",
+        "gpt-5.2",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex",
+        "gpt-5.1-chat-latest",
+        "gpt-5.1",
+        "gpt-5-pro",
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "gpt-5-codex",
+        "gpt-5-chat-latest",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
         "gpt-4o",
         "gpt-4o-mini",
-        "gpt-4o-2024-11-20",
-        // GPT-4 Turbo
-        "gpt-4-turbo",
-        "gpt-4-turbo-preview",
-        // o1/o3 reasoning models
-        "o1",
-        "o1-mini",
-        "o1-preview",
-        "o3-mini",
-        // GPT-4
-        "gpt-4",
-        // GPT-3.5
-        "gpt-3.5-turbo",
     ],
     anthropic: [
         // Claude 4.5 series (latest)


### PR DESCRIPTION
## Summary

- Fixed issue where the "Test" button was permanently showing "Verified" after API key verification
- Button now shows "Test" by default and only shows "Verified" briefly after a successful test
- Verified status is still shown via green badge in provider header/sidebar
- Updated OpenAI suggested models list with latest GPT-5.x series