### PR TITLE
fix: persist settings in Electron by using fixed port

### DIFF
--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -151,6 +151,9 @@ function SettingsContent({
     }, [open])
 
     const changeLanguage = (lang: string) => {
+        // Save locale to localStorage for persistence across restarts
+        localStorage.setItem("next-ai-draw-io-locale", lang)
+
         const parts = pathname.split("/")
         if (parts.length > 1 && i18n.locales.includes(parts[1] as Locale)) {
             parts[1] = lang


### PR DESCRIPTION
## Summary

Fixes settings not persisting in Electron desktop app (#399).

**Root cause:** The app used random ports (10000-65535) in production. Since localStorage is origin-specific, different ports on each restart meant different storage = lost settings.

**Fix:**
- Use fixed port 61337 in production (with sequential fallback if occupied)
- Add locale save/restore since language is URL-based