### PR TITLE
fix: handle fork PRs in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
@@ -37,11 +37,21 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      # For fork PRs, just fail if formatting is needed (can't push to forks)
+      - name: Fail if fork PR needs formatting
+        if: steps.changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::This PR has formatting issues. Please run 'npx @biomejs/biome check --write .' locally and push the changes."
+          git diff --stat
+          exit 1
+
+      # For same-repo PRs, commit and push the changes
       - name: Commit changes
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add .
           git commit -m "style: auto-format with Biome"
-          git push
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
## Summary

- Fix auto-format workflow failing for fork PRs
- Use `github.event.pull_request.head.sha` instead of `github.head_ref` for checkout (works for forks)
- For fork PRs: fail with helpful message if formatting is needed (can't push to forks)
- For same-repo PRs: auto-commit and push as before
- Simplified push logic: push directly from detached HEAD with `git push origin HEAD:<branch>`

## Problem

The workflow was failing for fork-based PRs (like PR #413) because:
1. It tried to checkout `github.head_ref` (branch name) which only exists in the fork, not the main repo
2. Even if checkout worked, `GITHUB_TOKEN` can't push to forks

## Solution

- Checkout by SHA instead of branch name (works for any PR)
- Detect fork PRs and fail gracefully with instructions for contributors
- Keep auto-format behavior for same-repo PRs