### PR TITLE
fix: make model selector label responsive to panel width

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -116,8 +116,8 @@ export function ModelSelector({
     const [showLabel, setShowLabel] = useState(true)
 
     // Threshold (px) under which we hide the label (tweak as needed)
-    const HIDE_THRESHOLD = 250
-    const SHOW_THRESHOLD = 250
+    const HIDE_THRESHOLD = 240
+    const SHOW_THRESHOLD = 260
     useEffect(() => {
         const el = wrapperRef.current
         if (!el) return


### PR DESCRIPTION
## Changes
- Added responsive behavior to the model selector based on chat panel width.
- Hide the model name and show only the model icon in narrow layouts.
- Automatically restore the model name when the panel width increases.
- Prevent resize feedback loops by observing the container instead of the button.
- Added hysteresis thresholds to avoid flicker during panel resizing.
 issue #437 