### PR TITLE
 fix: persist chat message feedback state to localStorage

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -234,7 +234,27 @@ export function ChatMessageDisplay({
     const [copyFailedMessageId, setCopyFailedMessageId] = useState<
         string | null
     >(null)
-    const [feedback, setFeedback] = useState<Record<string, "good" | "bad">>({})
+    const STORAGE_FEEDBACK_KEY = "next-ai-draw-io-feedback"
+    const [feedback, setFeedback] = useState<Record<string, "good" | "bad">>(
+        () => {
+            if (typeof window !== "undefined") {
+                const saved = localStorage.getItem(STORAGE_FEEDBACK_KEY)
+                if (saved) {
+                    try {
+                        return JSON.parse(saved)
+                    } catch {
+                        return {}
+                    }
+                }
+            }
+            return {}
+        },
+    )
+    useEffect(() => {
+        if (Object.keys(feedback).length > 0) {
+            localStorage.setItem(STORAGE_FEEDBACK_KEY, JSON.stringify(feedback))
+        }
+    }, [feedback])
     const [editingMessageId, setEditingMessageId] = useState<string | null>(
         null,
     )


### PR DESCRIPTION

## 🎯 Summary

Fixes the issue where thumbs up/down feedback on chat messages is lost after page reload. Feedback state is now persisted to localStorage and properly restored on mount.

## 🔧 Changes

- Added `STORAGE_FEEDBACK_KEY` constant for localStorage persistence
- Initialize feedback state from localStorage on component mount

## 📝 Files Changed

- `components/chat-message-display.tsx` - Added localStorage sync for feedback state
