### PR TITLE
fix: improve image not supported error detection for DeepSeek

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -335,7 +335,10 @@ export default function ChatPanel({
                 }
 
                 // Translate image not supported error
-                if (friendlyMessage.includes("image content block")) {
+                if (
+                    friendlyMessage.includes("image content block") ||
+                    friendlyMessage.toLowerCase().includes("image_url")
+                ) {
                     friendlyMessage = "This model doesn't support image input."
                 }
 


### PR DESCRIPTION
## Summary
- Extend error message detection to catch DeepSeek's `image_url` error
- Transform the error to a user-friendly message: "This model doesn't support image input."

Related to #326