### PR TITLE
fix: improve image not supported error detection for DeepSeek

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -906,3 +906,34 @@ export function supportsPromptCaching(modelId: string): boolean {
         modelId.startsWith("eu.anthropic")
     )
 }
+
+/**
+ * Check if a model supports image/vision input.
+ * Some models silently drop image parts without error (AI SDK warning only).
+ */
+export function supportsImageInput(modelId: string): boolean {
+    const lowerModelId = modelId.toLowerCase()
+
+    // Helper to check if model has vision capability indicator
+    const hasVisionIndicator =
+        lowerModelId.includes("vision") || lowerModelId.includes("vl")
+
+    // Models that DON'T support image/vision input (unless vision variant)
+    // Kimi K2 models don't support images
+    if (lowerModelId.includes("kimi") && !hasVisionIndicator) {
+        return false
+    }
+
+    // DeepSeek text models (not vision variants)
+    if (lowerModelId.includes("deepseek") && !hasVisionIndicator) {
+        return false
+    }
+
+    // Qwen text models (not vision variants like qwen-vl)
+    if (lowerModelId.includes("qwen") && !hasVisionIndicator) {
+        return false
+    }
+
+    // Default: assume model supports images
+    return true
+}


### PR DESCRIPTION
## Problem
When users upload images to models that don't support vision input (like Kimi K2, DeepSeek, or Qwen text models), the AI SDK silently drops the image parts. This causes the model to respond as if no image was uploaded, confusing users (issue #469).

## Solution
- Added `supportsImageInput()` function that detects models by name (kimi, deepseek, qwen) that don't support vision input
- Models with "vision" or "vl" in the name are treated as supporting images
- Returns 400 error with clear guidance when users try to upload images to unsupported models

Closes #469