### PR TITLE
fix: prevent flash of example panel and animations on page refresh

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -201,6 +201,7 @@ export default function ChatPanel({
 
     // Flag to track if we've restored from localStorage
     const hasRestoredRef = useRef(false)
+    const [isRestored, setIsRestored] = useState(false)
 
     // Ref to track latest chartXML for use in callbacks (avoids stale closure)
     const chartXMLRef = useRef(chartXML)
@@ -457,6 +458,8 @@ export default function ChatPanel({
             localStorage.removeItem(STORAGE_MESSAGES_KEY)
             localStorage.removeItem(STORAGE_XML_SNAPSHOTS_KEY)
             toast.error(dict.errors.sessionCorrupted)
+        } finally {
+            setIsRestored(true)
         }
     }, [setMessages])
 
@@ -1006,6 +1009,7 @@ export default function ChatPanel({
                     onRegenerate={handleRegenerate}
                     status={status}
                     onEditMessage={handleEditMessage}
+                    isRestored={isRestored}
                 />
             </main>
 


### PR DESCRIPTION
## Summary

Fixes visual glitches when refreshing the page with existing chat history:

- **Flash of example panel**: Previously showed example panel briefly before loading saved messages
- **Animation bounce**: All restored messages played entry animation on refresh  
- **Tool/reasoning expansion**: Tool calls and reasoning blocks expanded then collapsed

## Changes

- Add `isRestored` state to track localStorage restoration completion
- Show example panel only after confirming no saved messages exist
- Skip `animate-message-in` for restored messages
- Default tool calls to collapsed state for restored messages
- Default reasoning blocks to collapsed for restored messages