### PR TITLE
fix: faster message restore and skip panel animation on refresh

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -216,9 +216,6 @@ export default function ChatPanel({
         // Only animate when visibility changes from false to true (not on initial load)
         if (!prevIsVisibleRef.current && isVisible) {
             setShouldAnimatePanel(true)
-            // Reset after animation completes to allow re-animation on next toggle
-            const timer = setTimeout(() => setShouldAnimatePanel(false), 300)
-            return () => clearTimeout(timer)
         }
         prevIsVisibleRef.current = isVisible
     }, [isVisible])


### PR DESCRIPTION
## Problem
- Chat messages appeared after the panel on page refresh (noticeable delay)
- Panel slide-in animation played on every page refresh, causing unwanted visual shift

## Solution
- Use `useLayoutEffect` instead of `useEffect` for localStorage restore - runs synchronously before browser paint
- Track visibility state changes to only animate panel when user toggles it, not on page load
- Use `cn()` utility for cleaner conditional className