### PR TITLE
fix: use npm install instead of npm ci in electron workflow

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build and publish Electron app
         run: npm run dist:${{ matrix.platform }}


### PR DESCRIPTION
Fix cross-platform optional dependencies issue by using npm install instead of npm ci.