### PR TITLE
docs: add Cline MCP configuration instructions

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -64,6 +64,24 @@ Add to Cursor MCP config (`~/.cursor/mcp.json`):
 }
 ```
 
+### Cline (VS Code Extension)
+
+1. Click the **MCP Servers** icon in Cline's top menu bar
+2. Select the **Configure** tab
+3. Click **Configure MCP Servers** to edit `cline_mcp_settings.json`
+4. Add the drawio server:
+
+```json
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["@next-ai-drawio/mcp-server@latest"]
+    }
+  }
+}
+```
+
 ### Claude Code CLI
 
 ```bash


### PR DESCRIPTION
## Summary
- Added Cline (VS Code Extension) configuration instructions to the MCP server README
- Includes step-by-step guide based on official Cline documentation