### PR TITLE
fix: move toast notifications to bottom-left

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -943,10 +943,9 @@ export default function ChatPanel({
             )}
         >
             <Toaster
-                position="bottom-center"
+                position="bottom-left"
                 richColors
                 expand
-                style={{ position: "absolute" }}
                 toastOptions={{
                     style: {
                         maxWidth: "480px",


### PR DESCRIPTION
Toast notifications were appearing in the bottom-right, which could overlap with the chat input. Changed position to bottom-left and removed absolute positioning that was constraining toasts to the chat panel.