### PR TITLE
fix(docker): fix invalid YAML syntax in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         # - NEXT_PUBLIC_BASE_PATH=/nextaidrawio
     ports: ["3000:3000"]
     env_file: .env
-    environment:
-      # For subdirectory deployment, uncomment and set your path:
-      # NEXT_PUBLIC_BASE_PATH: /nextaidrawio
+    # environment:
+    #   # For subdirectory deployment, uncomment and set your path:
+    #   NEXT_PUBLIC_BASE_PATH: /nextaidrawio
     depends_on: [drawio]


### PR DESCRIPTION
Empty `environment:` mapping with only comments caused docker-compose validation error:

```
services.next-ai-draw-io.environment must be a mapping
```

Commented out the empty section to fix validation.