### PR TITLE
refactor: extract ToolCallCard and ChatLobby components

### DIFF
--- a/components/chat-message-display.tsx
+++ b/components/chat-message-display.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ai-elements/reasoning"
 import { ChatLobby } from "@/components/chat/ChatLobby"
 import { ToolCallCard } from "@/components/chat/ToolCallCard"
+import type { DiagramOperation, ToolPartLike } from "@/components/chat/types"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useDictionary } from "@/hooks/use-dictionary"
 import { getApiEndpoint } from "@/lib/base-path"
@@ -38,24 +39,6 @@ import {
     validateAndFixXml,
 } from "@/lib/utils"
 import ExamplePanel from "./chat-example-panel"
-
-// Types for streaming preview
-interface DiagramOperation {
-    operation: "update" | "add" | "delete"
-    cell_id: string
-    new_xml?: string
-}
-
-interface ToolPartLike {
-    type: string
-    toolCallId: string
-    state?: string
-    input?: {
-        xml?: string
-        operations?: DiagramOperation[]
-    } & Record<string, unknown>
-    output?: string
-}
 
 // Helper to extract complete operations from streaming input
 function getCompleteOperations(
@@ -648,7 +631,7 @@ export function ChatMessageDisplay({
                 <ChatLobby
                     sessions={sessions}
                     onSelectSession={onSelectSession || (() => {})}
-                    onDeleteSession={onDeleteSession || (() => {})}
+                    onDeleteSession={onDeleteSession}
                     setInput={setInput}
                     setFiles={setFiles}
                     dict={dict}

--- a/components/chat/ChatLobby.tsx
+++ b/components/chat/ChatLobby.tsx
@@ -32,7 +32,7 @@ interface SessionMetadata {
 interface ChatLobbyProps {
     sessions: SessionMetadata[]
     onSelectSession: (id: string) => void
-    onDeleteSession: (id: string) => void
+    onDeleteSession?: (id: string) => void
     setInput: (input: string) => void
     setFiles: (files: File[]) => void
     dict: {
@@ -177,18 +177,20 @@ export function ChatLobby({
                                         )}
                                     </div>
                                 </div>
-                                <button
-                                    type="button"
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        setSessionToDelete(session.id)
-                                        setDeleteDialogOpen(true)
-                                    }}
-                                    className="p-1.5 rounded-lg opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
-                                    title={dict.common.delete}
-                                >
-                                    <Trash2 className="w-4 h-4" />
-                                </button>
+                                {onDeleteSession && (
+                                    <button
+                                        type="button"
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            setSessionToDelete(session.id)
+                                            setDeleteDialogOpen(true)
+                                        }}
+                                        className="p-1.5 rounded-lg opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
+                                        title={dict.common.delete}
+                                    >
+                                        <Trash2 className="w-4 h-4" />
+                                    </button>
+                                )}
                             </div>
                         ))}
                     {sessions.filter((s) =>
@@ -254,7 +256,7 @@ export function ChatLobby({
                         </AlertDialogCancel>
                         <AlertDialogAction
                             onClick={() => {
-                                if (sessionToDelete) {
+                                if (sessionToDelete && onDeleteSession) {
                                     onDeleteSession(sessionToDelete)
                                 }
                                 setDeleteDialogOpen(false)

--- a/components/chat/ToolCallCard.tsx
+++ b/components/chat/ToolCallCard.tsx
@@ -4,23 +4,7 @@ import { Check, ChevronDown, ChevronUp, Copy, Cpu } from "lucide-react"
 import type { Dispatch, SetStateAction } from "react"
 import { CodeBlock } from "@/components/code-block"
 import { isMxCellXmlComplete } from "@/lib/utils"
-
-interface DiagramOperation {
-    operation: "update" | "add" | "delete"
-    cell_id: string
-    new_xml?: string
-}
-
-interface ToolPartLike {
-    type: string
-    toolCallId: string
-    state?: string
-    input?: {
-        xml?: string
-        operations?: DiagramOperation[]
-    } & Record<string, unknown>
-    output?: string
-}
+import type { DiagramOperation, ToolPartLike } from "./types"
 
 interface ToolCallCardProps {
     part: ToolPartLike
@@ -135,10 +119,7 @@ export function ToolCallCard({
     }
 
     return (
-        <div
-            key={callId}
-            className="my-3 rounded-xl border border-border/60 bg-muted/30 overflow-hidden"
-        >
+        <div className="my-3 rounded-xl border border-border/60 bg-muted/30 overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 bg-muted/50">
                 <div className="flex items-center gap-2">
                     <div className="w-6 h-6 rounded-md bg-primary/10 flex items-center justify-center">

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -1,0 +1,16 @@
+export interface DiagramOperation {
+    operation: "update" | "add" | "delete"
+    cell_id: string
+    new_xml?: string
+}
+
+export interface ToolPartLike {
+    type: string
+    toolCallId: string
+    state?: string
+    input?: {
+        xml?: string
+        operations?: DiagramOperation[]
+    } & Record<string, unknown>
+    output?: string
+}


### PR DESCRIPTION
## Summary

Extracts two self-contained UI components from the large chat-message-display.tsx file:

- **ToolCallCard.tsx** (279 lines) - Tool call UI with expand/collapse, copy, streaming states, error handling
- **ChatLobby.tsx** (272 lines) - Empty state with session history, search, delete dialog, collapsible examples

**chat-message-display.tsx**: 1760 → 1307 lines (-26%)

These components pass the maintainability test: "If deleted, would need to be recreated with the same boundaries."