### PR TITLE
fix: restore draw.io native save button functionality

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -172,13 +172,17 @@ export function ChatInput({
     onConfigureModels = () => {},
 }: ChatInputProps) {
     const dict = useDictionary()
-    const { diagramHistory, saveDiagramToFile } = useDiagram()
+    const {
+        diagramHistory,
+        saveDiagramToFile,
+        showSaveDialog,
+        setShowSaveDialog,
+    } = useDiagram()
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const fileInputRef = useRef<HTMLInputElement>(null)
     const [isDragging, setIsDragging] = useState(false)
     const [showHistory, setShowHistory] = useState(false)
-    const [showSaveDialog, setShowSaveDialog] = useState(false)
     // Allow retry when there's an error (even if status is still "streaming" or "submitted")
     const isDisabled =
         (status === "streaming" || status === "submitted") && !error


### PR DESCRIPTION
## Summary
- Fixes regression from PR #442 that broke draw.io's native save button (Ctrl+S)
- PR #296 originally fixed this by having `ChatInput` use the context's `showSaveDialog`
- PR #442 accidentally changed it to use local state, disconnecting the draw.io save button from the save dialog

## Changes
- Use `showSaveDialog` and `setShowSaveDialog` from diagram context instead of local state in `ChatInput`

## Testing
- Press Ctrl+S or use draw.io's File > Save menu - should now open the save dialog
- Download button in chat panel continues to work as before