### PR TITLE
feat: show success toast after diagram download completes

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -432,7 +432,12 @@ export function ChatInput({
                 open={showSaveDialog}
                 onOpenChange={setShowSaveDialog}
                 onSave={(filename, format) =>
-                    saveDiagramToFile(filename, format, sessionId)
+                    saveDiagramToFile(
+                        filename,
+                        format,
+                        sessionId,
+                        dict.save.savedSuccessfully,
+                    )
                 }
                 defaultFilename={`diagram-${new Date()
                     .toISOString()

--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { createContext, useContext, useEffect, useRef, useState } from "react"
 import type { DrawIoEmbedRef } from "react-drawio"
+import { toast } from "sonner"
 import type { ExportFormat } from "@/components/save-dialog"
 import { getApiEndpoint } from "@/lib/base-path"
 import {
@@ -27,6 +28,7 @@ interface DiagramContextType {
         filename: string,
         format: ExportFormat,
         sessionId?: string,
+        successMessage?: string,
     ) => void
     getThumbnailSvg: () => Promise<string | null>
     isDrawioReady: boolean
@@ -236,6 +238,7 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         filename: string,
         format: ExportFormat,
         sessionId?: string,
+        successMessage?: string,
     ) => {
         if (!drawioRef.current) {
             console.warn("Draw.io editor not ready")
@@ -296,6 +299,14 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
                 document.body.appendChild(a)
                 a.click()
                 document.body.removeChild(a)
+
+                // Show success toast after download is initiated
+                if (successMessage) {
+                    toast.success(successMessage, {
+                        position: "bottom-left",
+                        duration: 2500,
+                    })
+                }
 
                 // Delay URL revocation to ensure download completes
                 if (!url.startsWith("data:")) {

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -117,7 +117,8 @@
             "drawio": "Draw.io XML",
             "png": "PNG Image",
             "svg": "SVG Image"
-        }
+        },
+        "savedSuccessfully": "Saved successfully!"
     },
     "history": {
         "title": "Diagram History",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -117,7 +117,8 @@
             "drawio": "Draw.io XML",
             "png": "PNG 画像",
             "svg": "SVG 画像"
-        }
+        },
+        "savedSuccessfully": "保存完了！"
     },
     "history": {
         "title": "ダイアグラム履歴",

--- a/lib/i18n/dictionaries/zh.json
+++ b/lib/i18n/dictionaries/zh.json
@@ -117,7 +117,8 @@
             "drawio": "Draw.io XML",
             "png": "PNG 图片",
             "svg": "SVG 图片"
-        }
+        },
+        "savedSuccessfully": "保存成功！"
     },
     "history": {
         "title": "图表历史",


### PR DESCRIPTION
## Summary
Shows success toast after the diagram file is actually downloaded, not when the save dialog opens.

Closes #479

## Changes
- Add optional `successMessage` parameter to `saveDiagramToFile()` in diagram context
- Show toast after file download is initiated (after `a.click()`)
- Add i18n strings for success message (en/ja/zh)

## Why this approach
PR #484 showed the toast when the save dialog opened, which is misleading - the user sees "Saved successfully!" but hasn't actually saved anything yet. This PR shows the toast at the correct time - after the download is initiated.

## Testing
1. Click download button in chat panel
2. Select format and filename, click Save
3. Toast appears after file download starts (not when dialog opens)