### PR TITLE
fix: add NEXT_PUBLIC_BASE_PATH build arg for subdirectory deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ ENV NEXT_PUBLIC_DRAWIO_BASE_URL=${NEXT_PUBLIC_DRAWIO_BASE_URL}
 ARG NEXT_PUBLIC_SHOW_ABOUT_AND_NOTICE=false
 ENV NEXT_PUBLIC_SHOW_ABOUT_AND_NOTICE=${NEXT_PUBLIC_SHOW_ABOUT_AND_NOTICE}
 
+# Build-time argument for subdirectory deployment (e.g., /nextaidrawio)
+ARG NEXT_PUBLIC_BASE_PATH=""
+ENV NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH}
+
 # Build Next.js application (standalone mode)
 RUN npm run build
 


### PR DESCRIPTION
## Summary
Dockerfile was missing the ARG declaration to receive `NEXT_PUBLIC_BASE_PATH` from docker-compose build args, causing subdirectory deployment to fail even when properly configured in docker-compose.yml.

## Problem
PR #311 added subdirectory deployment support but forgot to add the corresponding ARG in the Dockerfile. Without this, the build arg passed from docker-compose.yml is silently ignored.

Fixes #478