### PR TITLE
fix: use OpenAI provider for Doubao multimodal models

### DIFF
--- a/app/api/validate-model/route.ts
+++ b/app/api/validate-model/route.ts
@@ -251,13 +251,26 @@ export async function POST(req: Request) {
             }
 
             case "doubao": {
-                // ByteDance Doubao uses DeepSeek-compatible API
-                const doubao = createDeepSeek({
-                    apiKey,
-                    baseURL:
-                        baseUrl || "https://ark.cn-beijing.volces.com/api/v3",
-                })
-                model = doubao(modelId)
+                // ByteDance Doubao: use DeepSeek for DeepSeek/Kimi models, OpenAI for others
+                const doubaoBaseUrl =
+                    baseUrl || "https://ark.cn-beijing.volces.com/api/v3"
+                const lowerModelId = modelId.toLowerCase()
+                if (
+                    lowerModelId.includes("deepseek") ||
+                    lowerModelId.includes("kimi")
+                ) {
+                    const doubao = createDeepSeek({
+                        apiKey,
+                        baseURL: doubaoBaseUrl,
+                    })
+                    model = doubao(modelId)
+                } else {
+                    const doubao = createOpenAI({
+                        apiKey,
+                        baseURL: doubaoBaseUrl,
+                    })
+                    model = doubao.chat(modelId)
+                }
                 break
             }
 

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -871,11 +871,24 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
                 overrides?.baseUrl ||
                 process.env.DOUBAO_BASE_URL ||
                 "https://ark.cn-beijing.volces.com/api/v3"
-            const doubaoProvider = createDeepSeek({
-                apiKey,
-                baseURL,
-            })
-            model = doubaoProvider(modelId)
+            const lowerModelId = modelId.toLowerCase()
+            // Use DeepSeek provider for DeepSeek/Kimi models, OpenAI for others (multimodal support)
+            if (
+                lowerModelId.includes("deepseek") ||
+                lowerModelId.includes("kimi")
+            ) {
+                const doubaoProvider = createDeepSeek({
+                    apiKey,
+                    baseURL,
+                })
+                model = doubaoProvider(modelId)
+            } else {
+                const doubaoProvider = createOpenAI({
+                    apiKey,
+                    baseURL,
+                })
+                model = doubaoProvider.chat(modelId)
+            }
             break
         }
 


### PR DESCRIPTION
## Problem
Doubao 1.6 vision model was not receiving images - the model reported it didn't get the image even though it was sent.

## Solution
The DeepSeek AI SDK provider was not properly formatting image content for Doubao's API. Changed to use OpenAI provider for Doubao models (multimodal support), while keeping DeepSeek provider for DeepSeek/Kimi models hosted on the Doubao platform.

## Changes
- Use `createOpenAI` for Doubao models by default (proper multimodal/vision support)
- Use `createDeepSeek` only when model name contains "deepseek" or "kimi"