### PR TITLE
Fix URL extraction loading state on failure

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -347,6 +347,12 @@ export function ChatInput({
 
             setShowUrlDialog(false)
         } catch (error) {
+            // Remove the URL from the data map on error
+            const newUrlData = urlData
+                ? new Map(urlData)
+                : new Map<string, UrlData>()
+            newUrlData.delete(url)
+            onUrlChange(newUrlData)
             showErrorToast(
                 <span className="text-muted-foreground">
                     {error instanceof Error


### PR DESCRIPTION

### Summary
Fixes an issue where the URL preview component would remain in a perpetual loading state when URL extraction failed.

### Details
Previously, when `extractUrlContent` threw an error, the URL entry remained in the `urlData` map with `isExtracting: true`, causing the loading spinner to never stop. Although an error toast was shown, the UI state was not fully reset.

This PR updates the error handling logic to:
- Remove the failed URL entry from the `urlData` map on extraction failure
- Properly clear the loading state

### Result
- Loading spinner no longer gets stuck