### PR TITLE
fix: add missing nanoid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "jsonrepair": "^3.13.1",
         "lucide-react": "^0.562.0",
         "motion": "^12.23.25",
+        "nanoid": "^3.3.11",
         "negotiator": "^1.0.0",
         "next": "^16.0.7",
         "ollama-ai-provider-v2": "^2.0.0",


### PR DESCRIPTION
<img width="643" height="134" alt="image" src="https://github.com/user-attachments/assets/78316d0f-18d3-4987-b458-b213c973c7b4" />

add missing nanoid dependency for session storage