### PR TITLE
fix: specify artifact-configuration-slug for SignPath

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -81,6 +81,7 @@ jobs:
           organization-id: '880a211d-2cd3-4e7b-8d04-3d1f8eb39df5'
           project-slug: 'next-ai-draw-io'
           signing-policy-slug: 'test-signing'
+          artifact-configuration-slug: 'windows-exe'
           github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: release-signed


### PR DESCRIPTION
Use 'windows-exe' artifact configuration instead of the default 'Initial version'