### PR TITLE
fix: update SiliconFlow default endpoint to .cn

### DIFF
--- a/app/api/validate-model/route.ts
+++ b/app/api/validate-model/route.ts
@@ -202,7 +202,7 @@ export async function POST(req: Request) {
             case "siliconflow": {
                 const sf = createOpenAI({
                     apiKey,
-                    baseURL: baseUrl || "https://api.siliconflow.com/v1",
+                    baseURL: baseUrl || "https://api.siliconflow.cn/v1",
                 })
                 model = sf.chat(modelId)
                 break

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -464,7 +464,7 @@ function validateProviderCredentials(provider: ProviderName): void {
  * - DEEPSEEK_API_KEY: DeepSeek API key
  * - DEEPSEEK_BASE_URL: DeepSeek endpoint (optional)
  * - SILICONFLOW_API_KEY: SiliconFlow API key
- * - SILICONFLOW_BASE_URL: SiliconFlow endpoint (optional, defaults to https://api.siliconflow.com/v1)
+ * - SILICONFLOW_BASE_URL: SiliconFlow endpoint (optional, defaults to https://api.siliconflow.cn/v1)
  * - SGLANG_API_KEY: SGLang API key
  * - SGLANG_BASE_URL: SGLang endpoint (optional)
  * - MODELSCOPE_API_KEY: ModelScope API key
@@ -721,7 +721,7 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
             const baseURL =
                 overrides?.baseUrl ||
                 process.env.SILICONFLOW_BASE_URL ||
-                "https://api.siliconflow.com/v1"
+                "https://api.siliconflow.cn/v1"
             const siliconflowProvider = createOpenAI({
                 apiKey,
                 baseURL,

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -80,7 +80,7 @@ export const PROVIDER_INFO: Record<
     deepseek: { label: "DeepSeek" },
     siliconflow: {
         label: "SiliconFlow",
-        defaultBaseUrl: "https://api.siliconflow.com/v1",
+        defaultBaseUrl: "https://api.siliconflow.cn/v1",
     },
     sglang: {
         label: "SGLang",


### PR DESCRIPTION
## Summary
- Update SiliconFlow default API endpoint from `.com` to `.cn`
- SiliconFlow is transitioning to `.cn` domain which uses Global Traffic Manager (GTM) for better global access
- The `.com` domain is being phased out

## Changes
- `lib/ai-providers.ts` - Update default endpoint
- `lib/types/model-config.ts` - Update default endpoint
- `app/api/validate-model/route.ts` - Update default endpoint
- `docs/*/ai-providers.md` - Update documentation with endpoint reference table

## Endpoint Reference
| Endpoint | Description |
|----------|-------------|
| `https://api.siliconflow.cn/v1` | Recommended (Global, uses GTM) |
| `https://api-st.siliconflow.cn/v1` | Overseas fallback |
| `https://api.siliconflow.com/v1` | Legacy (being phased out) |

## Impact
- Users with explicit `SILICONFLOW_BASE_URL` setting: No impact
- Users using default endpoint: Will use `.cn` instead of `.com` (should be transparent)