### PR TITLE
chore: reduce Renovate noise - monthly schedule, group major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "schedule": ["after 10am on saturday"],
+    "schedule": ["after 10am on the first day of the month"],
     "timezone": "Asia/Tokyo",
     "packageRules": [
         {
@@ -13,6 +13,7 @@
         {
             "matchUpdateTypes": ["major"],
             "matchPackagePatterns": ["*"],
+            "groupName": "major dependencies",
             "automerge": false
         },
         {


### PR DESCRIPTION
## Summary
- Change Renovate schedule from weekly (Saturday) to monthly (1st day of month)
- Group all major dependency updates into a single PR instead of separate PRs

This reduces the number of PRs created by Renovate while still keeping dependencies updated.