### PR TITLE
chore: add opencode.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ CLAUDE.md
 
 # edgeone
 .edgeone
+opencode.json


### PR DESCRIPTION
## Summary
- Add `opencode.json` to `.gitignore` to exclude local OpenCode configuration from version control