### PR TITLE
Improve UX: Disable save button when diagram is empty

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -27,6 +27,7 @@ import { isPdfFile, isTextFile } from "@/lib/pdf-utils"
 import { STORAGE_KEYS } from "@/lib/storage"
 import type { FlattenedModel } from "@/lib/types/model-config"
 import { extractUrlContent, type UrlData } from "@/lib/url-utils"
+import { isRealDiagram } from "@/lib/utils"
 import { FilePreviewList } from "./file-preview-list"
 
 const MAX_IMAGE_SIZE = 2 * 1024 * 1024 // 2MB
@@ -181,6 +182,7 @@ export function ChatInput({
 }: ChatInputProps) {
     const dict = useDictionary()
     const {
+        chartXML,
         diagramHistory,
         saveDiagramToFile,
         showSaveDialog,
@@ -454,7 +456,7 @@ export function ChatInput({
                             variant="ghost"
                             size="sm"
                             onClick={() => setShowSaveDialog(true)}
-                            disabled={isDisabled}
+                            disabled={isDisabled || !isRealDiagram(chartXML)}
                             tooltipContent={dict.chat.saveDiagram}
                             className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
                         >


### PR DESCRIPTION
This PR improves user experience by disabling the save button when the diagram canvas is empty. Currently, users can save an empty diagram, which results in downloading an empty PNG or a meaningless SVG file with no actual content.