### PR TITLE
fix: add missing @opentelemetry/api dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "@next/third-parties": "^16.0.6",
         "@opennextjs/cloudflare": "1.14.8",
         "@openrouter/ai-sdk-provider": "^1.5.4",
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.209.0",
         "@opentelemetry/sdk-trace-node": "^2.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",


### PR DESCRIPTION
<img width="993" height="152" alt="image" src="https://github.com/user-attachments/assets/d77840ff-0057-44fd-9293-8ebfe896cb88" />

add missing @opentelemetry/api dependency for langfuse.ts