### PR TITLE
fix(mcp): allow edit_diagram immediately after create_new_diagram

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "MCP server for Next AI Draw.io - AI-powered diagram generation with real-time browser preview",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -260,6 +260,7 @@ COMMON STYLES:
             // Update session state
             currentSession.xml = xml
             currentSession.version++
+            currentSession.lastGetDiagramTime = Date.now()
 
             // Push to embedded server state
             setState(currentSession.id, xml)


### PR DESCRIPTION
## Problem

After calling `create_new_diagram`, calling `edit_diagram` would fail with:
```
Error: You must call get_diagram first before edit_diagram.
```

This happened because `lastGetDiagramTime` was initialized to `0` in `start_session` and never updated in `create_new_diagram`, causing the 30-second timeout check to always fail.

## Solution

Set `lastGetDiagramTime = Date.now()` in `create_new_diagram` after creating the diagram, allowing immediate `edit_diagram` calls without requiring an intermediate `get_diagram`.

## Changes

- `packages/mcp-server/src/index.ts`: Add `lastGetDiagramTime` update in `create_new_diagram`
- `packages/mcp-server/package.json`: Bump version to 0.1.13

Fixes #534, Fixes #589