### PR TITLE
fix(chat): repair inconsistent quote escaping in edit_diagram JSON

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -473,6 +473,13 @@ ${userInputText}
                         inputToRepair = inputToRepair.replace(/:=/g, ": ")
                         // Fix `= "` instead of `: "`
                         inputToRepair = inputToRepair.replace(/=\s*"/g, ': "')
+                        // Fix inconsistent quote escaping in XML attributes within JSON strings
+                        // Pattern: attribute="value\" where opening quote is unescaped but closing is escaped
+                        // Example: y="-20\" should be y=\"-20\"
+                        inputToRepair = inputToRepair.replace(
+                            /(\w+)="([^"]*?)\\"/g,
+                            '$1=\\"$2\\"',
+                        )
                     }
                     // Use jsonrepair to fix truncated JSON
                     const repairedInput = jsonrepair(inputToRepair)


### PR DESCRIPTION
When the LLM generates edit_diagram tool calls, it sometimes produces inconsistent quote escaping in XML attributes within JSON strings. For example: y="-20\" instead of y=\"-20\"

This causes JSON parsing to fail, and jsonrepair cannot fix this pattern.

Added pre-processing regex to detect and fix cases where the opening quote is unescaped but the closing quote is escaped in attribute values.