### PR TITLE
fix(electron): properly dereference symlinks by copying actual content

### DIFF
--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -3,8 +3,48 @@
  * Copies node_modules to the standalone directory in the packaged app
  */
 
-const { cpSync, existsSync } = require("fs")
+const {
+    copyFileSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readdirSync,
+    statSync,
+} = require("fs")
 const path = require("path")
+
+/**
+ * Copy directory recursively, converting symlinks to regular files/directories.
+ * This is needed because cpSync with dereference:true does NOT convert symlinks.
+ * macOS codesign fails if bundle contains symlinks pointing outside the bundle.
+ */
+function copyDereferenced(src, dst) {
+    const lstat = lstatSync(src)
+
+    if (lstat.isSymbolicLink()) {
+        // Follow symlink and check what it points to
+        const stat = statSync(src)
+        if (stat.isDirectory()) {
+            // Symlink to directory: recursively copy the directory contents
+            mkdirSync(dst, { recursive: true })
+            for (const entry of readdirSync(src)) {
+                copyDereferenced(path.join(src, entry), path.join(dst, entry))
+            }
+        } else {
+            // Symlink to file: copy the actual file content
+            mkdirSync(path.join(dst, ".."), { recursive: true })
+            copyFileSync(src, dst)
+        }
+    } else if (lstat.isDirectory()) {
+        mkdirSync(dst, { recursive: true })
+        for (const entry of readdirSync(src)) {
+            copyDereferenced(path.join(src, entry), path.join(dst, entry))
+        }
+    } else {
+        mkdirSync(path.join(dst, ".."), { recursive: true })
+        copyFileSync(src, dst)
+    }
+}
 
 module.exports = async (context) => {
     const appOutDir = context.appOutDir
@@ -25,10 +65,7 @@ module.exports = async (context) => {
     console.log(`[afterPack] Copying node_modules to ${targetNodeModules}`)
 
     if (existsSync(sourceNodeModules) && existsSync(standaloneDir)) {
-        cpSync(sourceNodeModules, targetNodeModules, {
-            recursive: true,
-            dereference: true,
-        })
+        copyDereferenced(sourceNodeModules, targetNodeModules)
         console.log("[afterPack] node_modules copied successfully")
     } else {
         console.error("[afterPack] Source or target directory not found!")

--- a/scripts/prepare-electron-build.mjs
+++ b/scripts/prepare-electron-build.mjs
@@ -6,12 +6,53 @@
  * that electron-builder can properly include
  */
 
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import {
+    copyFileSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readdirSync,
+    rmSync,
+    statSync,
+} from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url))
 const rootDir = join(__dirname, "..")
+
+/**
+ * Copy directory recursively, converting symlinks to regular files/directories.
+ * This is needed because cpSync with dereference:true does NOT convert symlinks.
+ * macOS codesign fails if bundle contains symlinks pointing outside the bundle.
+ */
+function copyDereferenced(src, dst) {
+    const lstat = lstatSync(src)
+
+    if (lstat.isSymbolicLink()) {
+        // Follow symlink and check what it points to
+        const stat = statSync(src)
+        if (stat.isDirectory()) {
+            // Symlink to directory: recursively copy the directory contents
+            mkdirSync(dst, { recursive: true })
+            for (const entry of readdirSync(src)) {
+                copyDereferenced(join(src, entry), join(dst, entry))
+            }
+        } else {
+            // Symlink to file: copy the actual file content
+            mkdirSync(join(dst, ".."), { recursive: true })
+            copyFileSync(src, dst)
+        }
+    } else if (lstat.isDirectory()) {
+        mkdirSync(dst, { recursive: true })
+        for (const entry of readdirSync(src)) {
+            copyDereferenced(join(src, entry), join(dst, entry))
+        }
+    } else {
+        mkdirSync(join(dst, ".."), { recursive: true })
+        copyFileSync(src, dst)
+    }
+}
 
 const standaloneDir = join(rootDir, ".next", "standalone")
 const staticDir = join(rootDir, ".next", "static")
@@ -30,20 +71,19 @@ mkdirSync(targetDir, { recursive: true })
 
 // Copy standalone (includes node_modules)
 console.log("Copying standalone directory...")
-cpSync(standaloneDir, targetDir, { recursive: true, dereference: true })
+copyDereferenced(standaloneDir, targetDir)
 
 // Copy static files
 console.log("Copying static files...")
 const targetStaticDir = join(targetDir, ".next", "static")
-mkdirSync(targetStaticDir, { recursive: true })
-cpSync(staticDir, targetStaticDir, { recursive: true, dereference: true })
+copyDereferenced(staticDir, targetStaticDir)
 
 // Copy public folder (required for favicon-white.svg and other assets)
 console.log("Copying public folder...")
 const publicDir = join(rootDir, "public")
 const targetPublicDir = join(targetDir, "public")
 if (existsSync(publicDir)) {
-    cpSync(publicDir, targetPublicDir, { recursive: true, dereference: true })
+    copyDereferenced(publicDir, targetPublicDir)
 }
 
 console.log("Done! Files prepared in electron-standalone/")


### PR DESCRIPTION
## Problem

macOS arm64 Electron build fails with:
```
invalid destination for symbolic link in bundle
```

## Root Cause

1. **Next.js creates symlinks** in standalone output (e.g., `.next/node_modules/postcss-xxx -> ../../node_modules/postcss`)
2. **electron-builder 26.4.0** (PR #9007) now uses ad-hoc signing fallback for arm64, which runs `codesign --verify`
3. **Verification fails** because symlinks point outside the bundle
4. **Previous fix didn't work** because `cpSync` with `dereference: true` does NOT convert symlinks to files

## Solution

Custom `copyDereferenced()` function that:
- Detects symlinks using `lstatSync()`
- Follows them using `statSync()` to check if target is file or directory
- Copies actual file/directory content instead of symlink

Tested locally: `find electron-standalone -type l | wc -l` = **0 symlinks**

## Why v0.4.10 worked

electron-builder 26.0.12 **skipped signing entirely** for both x64 and arm64. The symlinks were always there but never validated.