### PR TITLE
fix(mcp): auto-redirect to active session when no sessionId provided

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "description": "MCP server for Next AI Draw.io - AI-powered diagram generation with real-time browser preview",
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Problem

Fixes #633

When users access the MCP server URL directly (e.g., `http://localhost:6002`) without the session parameter (`?mcp=xxx`), the browser shows "No session" with an infinite loading spinner. This is confusing UX.

## Solution

Auto-redirect to the most recent active session when no sessionId is provided in the URL:
- Added `getMostRecentSessionId()` function to find the most recently updated session
- Modified request handler to redirect (302) to the active session if one exists
- If no active session, still shows "No session" page (unchanged behavior)

## Testing

```bash
# With active session - redirects
curl -I "http://localhost:6002/"
# HTTP/1.1 302 Found
# Location: /?mcp=mcp-xxx

# With session param - works as before
curl -I "http://localhost:6002/?mcp=xxx"
# HTTP/1.1 200 OK
```