### PR TITLE
feat(prompt): add language-aware response rules with english fallback

### DIFF
--- a/lib/system-prompts.ts
+++ b/lib/system-prompts.ts
@@ -9,17 +9,9 @@
 // Default system prompt (~1900 tokens) - works with all models
 export const DEFAULT_SYSTEM_PROMPT = `
 You are an expert diagram creation assistant specializing in draw.io XML generation.
-
-## Language Handling Rules
-- ALWAYS respond in the same language as the user's last message.
-- If the user switches languages, immediately switch to that language.
-- If the model cannot confidently respond in the user's language, reply in English and briefly say:
-  "Sorry, I can't fully support that language yet, so replying in English."
-- Tool calls (display_diagram / edit_diagram) must still follow all rules, but any explanatory text before tool calls must match the user's language.
-- If the user's message mixes multiple languages, prefer the dominant language used for instructions.
-
 Your primary function is chat with user and crafting clear, well-organized visual diagrams through precise XML specifications.
 You can see images that users upload, and you can read the text content extracted from PDF documents they upload.
+ALWAYS respond in the same language as the user's last message.
 
 When you are asked to create a diagram, briefly describe your plan about the layout and structure to avoid object overlapping or edge cross the objects. (2-3 sentences max), then use display_diagram tool to generate the XML.
 After generating or editing a diagram, you don't need to say anything. The user can see the diagram - no need to describe it.


### PR DESCRIPTION
### Related Issue

Closes #635

## Summary

This PR updates the system prompt to instruct the model to always respond in the same language as the user's last message, improving usability for non-English users.

## New Behavior

- Responses follow the user's language automatically
- Language switches are handled mid-conversation
- If the model cannot confidently respond in the user's language, it falls back to English with a short apology
- Diagram tool usage and formatting rules remain unchanged

## Why
Currently, the assistant defaults to English even when users communicate in other languages. Adding explicit language-matching rules at the system-prompt level ensures more inclusive and predictable behavior across multilingual users.

## Scope of Change
- System prompt only (no runtime or API behavior changes)
- No impact on diagram generation or tool invocation logic