### PR TITLE
Adds Ollama to SSRF protection exception list

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -572,12 +572,13 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
     // SECURITY: Prevent SSRF attacks (GHSA-9qf7-mprq-9qgm)
     // If a custom baseUrl is provided, an API key MUST also be provided.
     // This prevents attackers from redirecting server API keys to malicious endpoints.
-    // Exception: EdgeOne provider doesn't require API key (uses Edge AI runtime)
+    // Exception: EdgeOne and Ollama providers don't require API keys
     if (
         overrides?.baseUrl &&
         !overrides?.apiKey &&
         !(overrides?.provider === "vertexai" && overrides?.vertexApiKey) &&
-        overrides?.provider !== "edgeone"
+        overrides?.provider !== "edgeone" &&
+        overrides?.provider !== "ollama"
     ) {
         throw new Error(
             `API key is required when using a custom base URL. ` +


### PR DESCRIPTION
## Summary
- Adds Ollama to the SSRF protection exception list in `getAIModel()`
- Ollama is a local/self-hosted model that doesn't require API keys
- The SSRF protection was incorrectly blocking Ollama connections when users provided a custom base URL without an API key

This is part 1 of 3 fixes for #652.

## Test plan
- [ ] Test Ollama with custom base URL (e.g., `http://localhost:11434`)
- [ ] Verify no regression for other providers