### PR TITLE
Adds Ollama to allowed client providers list

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -39,7 +39,7 @@ export interface ClientOverrides {
     baseUrlEnv?: string
 }
 
-// Providers that can be used with client-provided API keys
+// Providers that can be selected from client settings
 const ALLOWED_CLIENT_PROVIDERS: ProviderName[] = [
     "openai",
     "anthropic",
@@ -53,6 +53,7 @@ const ALLOWED_CLIENT_PROVIDERS: ProviderName[] = [
     "sglang",
     "gateway",
     "edgeone",
+    "ollama",
     "doubao",
     "modelscope",
 ]


### PR DESCRIPTION
## Summary
- Adds Ollama to `ALLOWED_CLIENT_PROVIDERS` list
- Allows users to select Ollama as a provider from client settings
- Previously, Ollama was blocked with "Invalid provider" error even though the UI supported it

This is part 2 of 3 fixes for #652.

## Test plan
- [ ] Select Ollama from provider dropdown in Settings
- [ ] Verify Ollama configuration is accepted by the server