### PR TITLE
Supports client-provided base URL for Ollama

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -836,16 +836,16 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
             break
         }
 
-        case "ollama":
-            if (process.env.OLLAMA_BASE_URL) {
-                const customOllama = createOllama({
-                    baseURL: process.env.OLLAMA_BASE_URL,
-                })
+        case "ollama": {
+            const baseURL = overrides?.baseUrl || process.env.OLLAMA_BASE_URL
+            if (baseURL) {
+                const customOllama = createOllama({ baseURL })
                 model = customOllama(modelId)
             } else {
                 model = ollama(modelId)
             }
             break
+        }
 
         case "openrouter": {
             const apiKey = resolveApiKey(overrides, "OPENROUTER_API_KEY")


### PR DESCRIPTION
## Summary
- Updates Ollama provider to use client-provided base URL from settings
- Client-provided base URL takes priority over `OLLAMA_BASE_URL` env var
- Allows users to configure custom Ollama endpoints (e.g., remote servers)

Previously, Ollama only used the `OLLAMA_BASE_URL` environment variable and ignored client settings.

This is part 3 of 3 fixes for #652.

## Test plan
- [ ] Configure Ollama with custom base URL in Settings (e.g., `http://192.168.1.100:11434`)
- [ ] Verify the custom URL is used instead of localhost default
- [ ] Verify env var still works when no client override is provided