### PR TITLE
fix: enable image support for Kimi K2.5 model

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1162,8 +1162,10 @@ export function supportsImageInput(modelId: string): boolean {
 
     // Models that DON'T support image/vision input (unless vision variant)
     // Kimi K2 doesn't support images, but K2.5 does
+    // Only block kimi-k2 specifically, not other Kimi models
     if (
-        lowerModelId.includes("kimi") &&
+        (lowerModelId.includes("kimi-k2") ||
+            lowerModelId.includes("kimi_k2")) &&
         !hasVisionIndicator &&
         !lowerModelId.includes("2.5") &&
         !lowerModelId.includes("k2.5")

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -168,6 +168,11 @@ describe("supportsImageInput", () => {
         expect(supportsImageInput("moonshot/kimi-k2")).toBe(false)
     })
 
+    it("returns true for Kimi K2.5 models (supports vision)", () => {
+        expect(supportsImageInput("kimi-k2.5")).toBe(true)
+        expect(supportsImageInput("moonshotai/kimi-k2.5")).toBe(true)
+    })
+
     it("returns false for DeepSeek text models", () => {
         expect(supportsImageInput("deepseek-chat")).toBe(false)
         expect(supportsImageInput("deepseek-coder")).toBe(false)


### PR DESCRIPTION
## Summary

Fixes the incorrect error message when using Kimi K2.5 with images:
> The model "moonshotai/kimi-k2.5" does not support image input.

Kimi K2.5 does support image input, but was incorrectly blocked by the `supportsImageInput` check that excluded all Kimi models without "vision" in the name. Updated the condition to only exclude the older K2 model while allowing K2.5.