### PR TITLE
feat: add API key load balancing for providers

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -186,7 +186,7 @@ async function handleChatRequest(req: Request): Promise<Response> {
 
     // Check if this is a server model with custom env var names
     let serverModelConfig: {
-        apiKeyEnv?: string
+        apiKeyEnv?: string | string[]
         baseUrlEnv?: string
         provider?: string
     } = {}

--- a/lib/server-model-config.ts
+++ b/lib/server-model-config.ts
@@ -14,9 +14,12 @@ export const ServerProviderSchema = z.object({
     name: z.string().min(1),
     provider: ProviderNameSchema,
     models: z.array(z.string().min(1)),
-    // Optional: custom environment variable name for API key
-    // e.g., "OPENAI_API_KEY_TEAM_A" instead of default "OPENAI_API_KEY"
-    apiKeyEnv: z.string().min(1).optional(),
+    // Optional: custom environment variable name(s) for API key
+    // Can be a single string or array of strings for load balancing
+    // e.g., "OPENAI_API_KEY_TEAM_A" or ["OPENAI_KEY_1", "OPENAI_KEY_2"]
+    apiKeyEnv: z
+        .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+        .optional(),
     // Optional: custom environment variable name for base URL
     baseUrlEnv: z.string().min(1).optional(),
     // Optional: mark the first model in this provider as the default
@@ -36,8 +39,9 @@ export interface FlattenedServerModel {
     provider: ProviderName
     providerLabel: string
     isDefault: boolean
-    // Custom env var names for credentials (optional)
-    apiKeyEnv?: string
+    // Custom env var name(s) for API key (optional)
+    // Can be a single string or array of strings for load balancing
+    apiKeyEnv?: string | string[]
     baseUrlEnv?: string
 }
 

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -73,8 +73,9 @@ export interface FlattenedModel {
     source?: "user" | "server"
     // Whether this model is the server default (matches AI_MODEL env var)
     isDefault?: boolean
-    // Custom env var names for server models (allows multiple API keys per provider)
-    apiKeyEnv?: string
+    // Custom env var name(s) for server models
+    // Can be a single string or array of strings for load balancing
+    apiKeyEnv?: string | string[]
     baseUrlEnv?: string
 }
 


### PR DESCRIPTION
## Summary

Add support for multiple API keys per provider with random selection for load balancing.

When `AI_MODELS_CONFIG` has multiple `apiKeyEnv` values for a provider, each request will randomly select one available key, distributing load across multiple API keys.

## Changes

- Update schema to accept `apiKeyEnv` as either a single string or an array of strings
- Add random key selection in `resolveApiKey()` function
- Update validation to ensure at least one key from the array exists
- Add tests for the array format support

## Usage Example

```env
OPENAI_KEY_1=sk-xxx1
OPENAI_KEY_2=sk-xxx2
OPENAI_KEY_3=sk-xxx3
```

```json
{
  "providers": [{
    "name": "OpenAI LoadBalanced",
    "provider": "openai",
    "models": ["gpt-4o"],
    "apiKeyEnv": ["OPENAI_KEY_1", "OPENAI_KEY_2", "OPENAI_KEY_3"]
  }]
}
```