### PR TITLE
make "Show unvalidated models" clickable #679

### DIFF
--- a/components/model-config-dialog.tsx
+++ b/components/model-config-dialog.tsx
@@ -1661,12 +1661,16 @@ export function ModelConfigDialog({
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                             <Switch
+                                id="show-unvalidated-models"
                                 checked={modelConfig.showUnvalidatedModels}
                                 onCheckedChange={
                                     modelConfig.setShowUnvalidatedModels
                                 }
                             />
-                            <Label className="text-xs text-muted-foreground cursor-pointer">
+                            <Label
+                                htmlFor="show-unvalidated-models"
+                                className="text-xs text-muted-foreground cursor-pointer"
+                            >
                                 {dict.modelConfig.showUnvalidatedModels}
                             </Label>
                         </div>


### PR DESCRIPTION
Makes the label text clickable to toggle the switch in the Model Config dialog, following standard form UX patterns and improving accessibility.

Solves #679 

After:

https://github.com/user-attachments/assets/ac27d98e-fe6d-48b6-88b8-ce224766ee54

