### PR TITLE
Fix: return clear error for PDF URLs in content extraction

### DIFF
--- a/app/api/parse-url/route.ts
+++ b/app/api/parse-url/route.ts
@@ -5,6 +5,7 @@ import { allowPrivateUrls, isPrivateUrl } from "@/lib/ssrf-protection"
 
 const MAX_CONTENT_LENGTH = 150000 // Match PDF limit
 const EXTRACT_TIMEOUT_MS = 15000
+const USER_AGENT = "Mozilla/5.0 (compatible; NextAIDrawio/1.0)"
 
 export async function POST(req: Request) {
     try {
@@ -34,18 +35,14 @@ export async function POST(req: Request) {
                 { status: 400 },
             )
         }
+        const headController = new AbortController()
+        const headTimeout = setTimeout(() => headController.abort(), 3000)
         try {
-            const headController = new AbortController()
-            const headTimeout = setTimeout(() => headController.abort(), 3000)
-
             const headResponse = await fetch(url, {
                 method: "HEAD",
-                headers: {
-                    "User-Agent": "Mozilla/5.0 (compatible; NextAIDrawio/1.0)",
-                },
+                headers: { "User-Agent": USER_AGENT },
                 signal: headController.signal,
             })
-            clearTimeout(headTimeout)
             const contentType = headResponse.headers.get("content-type")
             if (contentType?.includes("application/pdf")) {
                 return NextResponse.json(
@@ -60,6 +57,8 @@ export async function POST(req: Request) {
                 "HEAD pre-check failed, proceeding with extraction:",
                 err,
             )
+        } finally {
+            clearTimeout(headTimeout)
         }
 
         // Extract article content with timeout to avoid tying up server resources
@@ -71,9 +70,7 @@ export async function POST(req: Request) {
         let article
         try {
             article = await extract(url, undefined, {
-                headers: {
-                    "User-Agent": "Mozilla/5.0 (compatible; NextAIDrawio/1.0)",
-                },
+                headers: { "User-Agent": USER_AGENT },
                 signal: controller.signal,
             })
         } catch (err: any) {


### PR DESCRIPTION
### What I Changed

I went with 422 instead of 400 here  because I thoguh the request itself is valid , but the content at the URL can't be processed. 422 fits that better than  400. Happy to change it if you prefer something else though.

I used a separate `AbortController` with a 3s timeout so it doesn't interfere with the main extraction timeout. If the HEAD request fails for any reason (server doesn't support HEAD, timeout, network error), it logs a warning and falls through to the extractor 

## Screenshot
<img width="958" height="507" alt="image" src="https://github.com/user-attachments/assets/4fa8dd8a-144a-4ca6-927e-a6bf88a8833b" />

Closes #693
