### PR TITLE
fix: Enable build-time variable to tell electron skip binary DL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 
 # Install dependencies
+ARG ELECTRON_SKIP_BINARY_DOWNLOAD=1
 RUN npm install
 
 # Stage 2: Build application


### PR DESCRIPTION
By default, the electron package tries to download binaries using a direct HTTP connection. This fix adds an build-time varaible to the Dockerfile to skip the download of the electron binary, which is enabled by default. 

Note that if binary download is still wanted for some reason, and the download is happening behidn a proxy, one must modify the Dockerfile to use ELECTRON_GET_USE_PROXY and supply http_proxy, https_proxy, NO_PROXY build args.