### PR TITLE
feat: add qwen3.5-plus vision model support

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1217,7 +1217,12 @@ export function supportsImageInput(modelId: string): boolean {
     }
 
     // Qwen text models (not vision variants like qwen-vl)
-    if (lowerModelId.includes("qwen") && !hasVisionIndicator) {
+    // qwen3.5-plus is a vision model
+    if (
+        lowerModelId.includes("qwen") &&
+        !hasVisionIndicator &&
+        !lowerModelId.includes("qwen3.5-plus")
+    ) {
         return false
     }
 

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -264,6 +264,7 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
         "Qwen/Qwen2.5-Coder-32B-Instruct",
         "Qwen/Qwen2.5-7B-Instruct",
         "Qwen/Qwen2-VL-72B-Instruct",
+        "qwen3.5-plus",
     ],
     sglang: [
         // SGLang is OpenAI-compatible, models depend on deployment
@@ -293,6 +294,7 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
         "Qwen/Qwen3-235B-A22B-Instruct-2507",
         "Qwen/Qwen3-VL-235B-A22B-Instruct",
         "Qwen/Qwen3-32B",
+        "qwen3.5-plus",
         // DeepSeek
         "deepseek-ai/DeepSeek-R1-0528",
         "deepseek-ai/DeepSeek-V3.2",


### PR DESCRIPTION
## Summary
- Add `qwen3.5-plus` to SiliconFlow and ModelScope suggested models list
- Mark `qwen3.5-plus` as a vision-capable model in `supportsImageInput` check

## Test plan
- [ ] Verify `qwen3.5-plus` appears in model selector for SiliconFlow provider
- [ ] Verify `qwen3.5-plus` appears in model selector for ModelScope provider
- [ ] Verify image upload works with `qwen3.5-plus` model

🤖 Generated with [Claude Code](https://claude.com/claude-code)