### PR TITLE
fix: resolve Electron startup failures on Windows and Linux

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -94,7 +94,8 @@ if (!gotTheLock) {
             if (
                 url.includes("diagrams.net") ||
                 url.includes("draw.io") ||
-                url.startsWith("http://localhost")
+                url.startsWith("http://localhost") ||
+                url.startsWith("http://127.0.0.1")
             ) {
                 return { action: "allow" }
             }

--- a/electron/main/next-server.ts
+++ b/electron/main/next-server.ts
@@ -68,7 +68,7 @@ export async function startNextServer(): Promise<string> {
     const env: Record<string, string> = {
         NODE_ENV: "production",
         PORT: String(port),
-        HOSTNAME: "localhost",
+        HOSTNAME: "127.0.0.1",
         // Enable Node.js built-in proxy support for fetch (Node.js 24+)
         NODE_USE_ENV_PROXY: "1",
     }

--- a/electron/main/port-manager.ts
+++ b/electron/main/port-manager.ts
@@ -9,9 +9,11 @@ import { app } from "electron"
 const PORT_CONFIG = {
     // Development mode uses fixed port for hot reload compatibility
     development: 6002,
-    // Production mode uses fixed port (61337) to preserve localStorage
-    // Falls back to sequential ports if unavailable
-    production: 61337,
+    // Legacy production port — tried first to preserve localStorage for existing users
+    legacyProduction: 61337,
+    // New production port below the ephemeral range (49152-65535)
+    // to avoid conflicts with Windows Hyper-V / ephemeral port reservations
+    production: 13370,
     // Maximum attempts to find an available port (fallback)
     maxAttempts: 100,
 }
@@ -27,7 +29,10 @@ let allocatedPort: number | null = null
 export function isPortAvailable(port: number): Promise<boolean> {
     return new Promise((resolve) => {
         const server = net.createServer()
-        server.once("error", () => resolve(false))
+        server.once("error", (err: NodeJS.ErrnoException) => {
+            console.warn(`Port ${port} unavailable: ${err.code}`)
+            resolve(false)
+        })
         server.once("listening", () => {
             server.close()
             resolve(true)
@@ -39,12 +44,12 @@ export function isPortAvailable(port: number): Promise<boolean> {
 /**
  * Find an available port
  * - In development: uses fixed port (6002)
- * - In production: uses fixed port (61337) to preserve localStorage
+ * - In production: uses fixed port (13370) to preserve localStorage
  * - Falls back to sequential ports if preferred port is unavailable
+ * - Last resort: lets the OS assign a port (port 0)
  *
  * @param reuseExisting If true, try to reuse the previously allocated port
  * @returns Promise<number> The available port
- * @throws Error if no available port found after max attempts
  */
 export async function findAvailablePort(reuseExisting = true): Promise<number> {
     const isDev = !app.isPackaged
@@ -64,7 +69,16 @@ export async function findAvailablePort(reuseExisting = true): Promise<number> {
         allocatedPort = null
     }
 
-    // Try preferred port first
+    // In production, try legacy port first to preserve existing users' localStorage
+    if (!isDev) {
+        const legacyPort = PORT_CONFIG.legacyProduction
+        if (await isPortAvailable(legacyPort)) {
+            allocatedPort = legacyPort
+            return legacyPort
+        }
+    }
+
+    // Try preferred port
     if (await isPortAvailable(preferredPort)) {
         allocatedPort = preferredPort
         return preferredPort
@@ -84,9 +98,23 @@ export async function findAvailablePort(reuseExisting = true): Promise<number> {
         }
     }
 
-    throw new Error(
-        `Failed to find available port after ${PORT_CONFIG.maxAttempts} attempts`,
+    // Last resort: let the OS pick an available port
+    console.warn(
+        "All sequential ports failed. Requesting OS-assigned port (localStorage may not persist across restarts).",
     )
+    const osPort = await new Promise<number>((resolve, reject) => {
+        const server = net.createServer()
+        server.once("error", reject)
+        server.once("listening", () => {
+            const addr = server.address()
+            const port = (addr as net.AddressInfo).port
+            server.close(() => resolve(port))
+        })
+        server.listen(0, "127.0.0.1")
+    })
+    allocatedPort = osPort
+    console.log(`OS assigned port: ${osPort}`)
+    return osPort
 }
 
 /**
@@ -113,5 +141,5 @@ export function getServerUrl(): string {
             "No port allocated yet. Call findAvailablePort() first.",
         )
     }
-    return `http://localhost:${allocatedPort}`
+    return `http://127.0.0.1:${allocatedPort}`
 }

--- a/electron/main/window-manager.ts
+++ b/electron/main/window-manager.ts
@@ -66,7 +66,11 @@ export function createWindow(serverUrl: string): BrowserWindow {
 
     // Handle page title updates
     mainWindow.webContents.on("page-title-updated", (event, title) => {
-        if (title && !title.includes("localhost")) {
+        if (
+            title &&
+            !title.includes("localhost") &&
+            !title.includes("127.0.0.1")
+        ) {
             mainWindow?.setTitle(title)
         } else {
             event.preventDefault()


### PR DESCRIPTION
## Summary

Fixes two related Electron startup bugs in port-manager.ts and next-server.ts:

- **Windows (#705)**: Production port 61337 falls in the Hyper-V/ephemeral range (49152-65535), causing all 100 port attempts to fail. Added 13370 as new default below that range.
- **Linux (#684)**: Server binds to `localhost` (may resolve to IPv6 `::1`) but health check connects to `127.0.0.1` (IPv4), causing a 30s timeout. Now all URLs use `127.0.0.1` consistently.

### Port selection order (production)
1. **61337** (legacy) — tried first to preserve existing users' localStorage/IndexedDB data
2. **13370** (new default) — below the ephemeral range, safe on Windows
3. Sequential fallback (13371–13470)
4. OS-assigned port (port 0) — last resort, never throws

### Other changes
- `getServerUrl()` returns `http://127.0.0.1:PORT` instead of `http://localhost:PORT`
- Updated `localhost` guards in `index.ts` and `window-manager.ts` to also match `127.0.0.1`
- `isPortAvailable()` now logs error codes (EACCES vs EADDRINUSE) for debugging

Related: #705, #684