### PR TITLE
fix: Changes to make npm run check GH status check pass

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -5,7 +5,6 @@ import {
     History,
     Image as ImageIcon,
     Link,
-    Loader2,
     Send,
     Square,
 } from "lucide-react"

--- a/tests/e2e/history-restore.spec.ts
+++ b/tests/e2e/history-restore.spec.ts
@@ -1,7 +1,6 @@
 import { SINGLE_BOX_XML } from "./fixtures/diagrams"
 import {
     expect,
-    expectBeforeAndAfterReload,
     getChatInput,
     getIframe,
     getIframeContent,

--- a/tests/e2e/iframe-interaction.spec.ts
+++ b/tests/e2e/iframe-interaction.spec.ts
@@ -1,7 +1,6 @@
 import { TEST_NODE_XML } from "./fixtures/diagrams"
 import {
     expect,
-    getChatInput,
     getIframe,
     getIframeContent,
     sendMessage,

--- a/tests/e2e/language.spec.ts
+++ b/tests/e2e/language.spec.ts
@@ -1,6 +1,5 @@
 import {
     expect,
-    expectBeforeAndAfterReload,
     getChatInput,
     getIframe,
     openSettings,

--- a/tests/e2e/multi-turn.spec.ts
+++ b/tests/e2e/multi-turn.spec.ts
@@ -3,7 +3,6 @@ import {
     createMixedMock,
     createMultiTurnMock,
     expect,
-    getChatInput,
     sendMessage,
     test,
     waitForComplete,

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,10 +1,4 @@
-import {
-    expect,
-    getIframe,
-    getSettingsButton,
-    openSettings,
-    test,
-} from "./lib/fixtures"
+import { expect, getIframe, openSettings, test } from "./lib/fixtures"
 
 test.describe("Settings", () => {
     test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
The Lint & Unit Tests PR status check is failing at the "Run lint" step over a half-dozen issues. This is causing all PR's to fail the Lint & Unit tets check. This fix resolves those issues.