### PR TITLE
feat: Enable minimal chat panel when self-hosted flag is true

### DIFF
--- a/components/chat-example-panel.tsx
+++ b/components/chat-example-panel.tsx
@@ -70,11 +70,11 @@ function ExampleCard({
 export default function ExamplePanel({
     setInput,
     setFiles,
-    minimal = false,
+    minimal,
 }: {
     setInput: (input: string) => void
     setFiles: (files: File[]) => void
-    minimal?: boolean
+    minimal: boolean
 }) {
     const dict = useDictionary()
 

--- a/components/chat/ChatLobby.tsx
+++ b/components/chat/ChatLobby.tsx
@@ -94,8 +94,14 @@ export function ChatLobby({
     const hasHistory = sessions.length > 0
 
     if (!hasHistory) {
-        // Show full examples when no history
-        return <ExamplePanel setInput={setInput} setFiles={setFiles} />
+        // Show full examples when there is no history (and NEXT_PUBLIC_SELFHOSTED !== "true")
+        return (
+            <ExamplePanel
+                setInput={setInput}
+                setFiles={setFiles}
+                minimal={process.env.NEXT_PUBLIC_SELFHOSTED === "true"}
+            />
+        )
     }
 
     // Show history + collapsible examples when there are sessions

--- a/env.example
+++ b/env.example
@@ -141,4 +141,5 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 # which triggers the client UI to display messages suggesting self-hosting or sponsorship.
 # This switch allows self-hosted users to provide custom messages in response to a 429 code,
 # in messageTokenSelfHosted, messageApiSelfHosted, and tipSelfHosted translation strings.
+# It also turns off the MCP server advertisement in the chat examples.
 # NEXT_PUBLIC_SELFHOSTED=true


### PR DESCRIPTION
The existing code invokes the ExamplePanel component that supports a minimal flag that shortens the content of the examples, and more importantly, omits MCP server promotion.

This enhancement will pass minimal: true if NEXT_PUBLIC_SELFHOSTED=true

This enhancement also makes the minimal argument required (there is only a single caller).