### PR TITLE
docs: update contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,6 +47,10 @@ To run tests with UI mode:
 npx playwright test --ui
 ```
 
+## Before You Start
+
+For **significant changes** (new features, architecture changes, large refactors, etc.), please **open an issue first** to discuss your proposal before writing code. This helps avoid wasted effort and ensures alignment with the project direction. Small bug fixes and minor improvements can go straight to a PR.
+
 ## Pull Requests
 
 1. Create a feature branch
@@ -56,6 +60,12 @@ npx playwright test --ui
 5. Submit PR against `main` with a clear description
 
 CI will run the full test suite on your PR.
+
+## Code Review
+
+This project uses GitHub Copilot for automated code review. If you receive review comments from Copilot on your PR:
+- **Valid suggestions**: Please address them in your code.
+- **Invalid or irrelevant suggestions**: Feel free to click "Resolve" to dismiss them.
 
 ## Issues
 


### PR DESCRIPTION
## Summary
- Ask contributors to open an issue first before making significant changes
- Add guidance on handling GitHub Copilot auto-review comments