### PR TITLE
fix: biome schema check errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+    "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
             },
             "devDependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",
-                "@biomejs/biome": "^2.3.10",
+                "@biomejs/biome": "^2.4.4",
                 "@playwright/test": "^1.57.0",
                 "@tailwindcss/postcss": "^4",
                 "@tailwindcss/typography": "^0.5.19",
@@ -12245,6 +12245,7 @@
             "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.8.1",
                 "builder-util": "26.8.1",
@@ -12878,17 +12879,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/encoding": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
-            }
-        },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -13425,6 +13415,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     },
     "devDependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
-        "@biomejs/biome": "^2.3.10",
+        "@biomejs/biome": "^2.4.4",
         "@playwright/test": "^1.57.0",
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
Stronger fix for commit dd9d79d2d67a47fdd5ca9d72cdf3aa4f1103f956

Update the carat version of biome to ^2.4.4
(which is currently what is installed with ^2.3.10) and switch the biome.json to use the local configuration schema

This is because npm will take every minor version bump, but config schema will never be able to catch up.
Instead, point at the local config schema version, so that these are always in sync without
locking biome to a specific major/minor/patch release.

Specific error that is fixed when "biome ci" is invoked:

```
  ℹ The configuration schema version does not match the CLI version (local installed version)

  > 2 │     "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
      │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```