### PR TITLE
fix(electron): include package.json in asar for electron-builder 26.8

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -11,6 +11,7 @@ afterPack: ./scripts/afterPack.cjs
 
 files:
   - dist-electron/**/*
+  - package.json
   - "!node_modules"
 
 asarUnpack:


### PR DESCRIPTION
electron-builder 26.8.x no longer auto-includes package.json when a custom files array is specified, causing the main entry file to not be found in the asar archive.

This fixes the v0.4.13 Electron build failure.