### PR TITLE
fix(electron): use explicit file sets for electron-builder 26.8 compatibility

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -10,9 +10,13 @@ directories:
 afterPack: ./scripts/afterPack.cjs
 
 files:
-  - dist-electron/**/*
-  - package.json
-  - "!node_modules"
+  - from: dist-electron
+    to: dist-electron
+    filter:
+      - "**/*"
+  - from: .
+    filter:
+      - package.json
 
 asarUnpack:
   - "**/*.node"


### PR DESCRIPTION
Use explicit from/to/filter file sets instead of top-level globs to avoid a regression in electron-builder 26.8.x where dist-electron files were not being included in the asar archive.

Tested locally - macOS build succeeds with this config.