### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/docs/cn/ai-providers.md
+++ b/docs/cn/ai-providers.md
@@ -215,7 +215,7 @@ MiniMax 支持两种 API 格式：
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.5
+AI_MODEL=MiniMax-M2.7
 ```
 
 可选配置：

--- a/docs/en/ai-providers.md
+++ b/docs/en/ai-providers.md
@@ -230,7 +230,7 @@ MiniMax supports two API formats:
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.5
+AI_MODEL=MiniMax-M2.7
 ```
 
 Optional configuration:

--- a/docs/ja/ai-providers.md
+++ b/docs/ja/ai-providers.md
@@ -215,7 +215,7 @@ MiniMax は 2 つの API 形式をサポートしています：
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.5
+AI_MODEL=MiniMax-M2.7
 ```
 
 オプション設定：

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -345,6 +345,8 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
     ],
     minimax: [
         // MiniMax models (Anthropic-compatible API)
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
     ],


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model as default.

## Changes
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models (M2.5, M2.5-highspeed) as available alternatives
- Update documentation in EN/CN/JA

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Testing
- Verified model list includes M2.7 at the top
- All existing M2.5 models preserved for backward compatibility
- Documentation updated across all three language versions