### PR TITLE
fix(mcp-server): restrict CORS to same-origin only

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@next-ai-drawio/mcp-server",
-            "version": "0.1.16",
+            "version": "0.1.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.4",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "description": "MCP server for Next AI Draw.io - AI-powered diagram generation with real-time browser preview",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp-server/src/http-server.ts
+++ b/packages/mcp-server/src/http-server.ts
@@ -198,9 +198,12 @@ function handleRequest(
 ): void {
     const url = new URL(req.url || "/", `http://localhost:${serverPort}`)
 
-    res.setHeader("Access-Control-Allow-Origin", "*")
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type")
+    const requestOrigin = req.headers.origin
+    if (requestOrigin === `http://localhost:${serverPort}`) {
+        res.setHeader("Access-Control-Allow-Origin", requestOrigin)
+        res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        res.setHeader("Access-Control-Allow-Headers", "Content-Type")
+    }
 
     if (req.method === "OPTIONS") {
         res.writeHead(204)


### PR DESCRIPTION
## Summary

Replace wildcard `Access-Control-Allow-Origin: *` with same-origin check on the MCP server's embedded HTTP server. This prevents external websites from making cross-origin requests to read/write diagram data via the local MCP server APIs.

Relates to #755.