### PR TITLE
feat: add Editable SVG (xmlsvg) export option

### DIFF
--- a/components/save-dialog.tsx
+++ b/components/save-dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/select"
 import { useDictionary } from "@/hooks/use-dictionary"
 
-export type ExportFormat = "drawio" | "png" | "svg"
+export type ExportFormat = "drawio" | "png" | "svg" | "xmlsvg"
 
 interface SaveDialogProps {
     open: boolean
@@ -72,6 +72,11 @@ export function SaveDialog({
         {
             value: "svg" as const,
             label: dict.save.formats.svg,
+            extension: ".svg",
+        },
+        {
+            value: "xmlsvg" as const,
+            label: dict.save.formats.xmlsvg,
             extension: ".svg",
         },
     ]

--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -296,7 +296,7 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         }
 
         // Map format to draw.io export format
-        const drawioFormat = format === "drawio" ? "xmlsvg" : format
+        const drawioFormat = format === "drawio" || format === "xmlsvg" ? "xmlsvg" : format
 
         // Set up the resolver before triggering export
         saveResolverRef.current = {
@@ -315,6 +315,11 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
                     fileContent = xmlContent
                     mimeType = "application/xml"
                     extension = ".drawio"
+                } else if (format === "xmlsvg") {
+                    // Editable SVG: save raw xmlsvg content (SVG with embedded draw.io XML)
+                    fileContent = exportData
+                    mimeType = "image/svg+xml"
+                    extension = ".svg"
                 } else if (format === "png") {
                     // PNG data comes as base64 data URL
                     fileContent = exportData

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -140,7 +140,8 @@
         "formats": {
             "drawio": "Draw.io XML",
             "png": "PNG Image",
-            "svg": "SVG Image"
+            "svg": "SVG Image",
+            "xmlsvg": "Editable SVG"
         },
         "savedSuccessfully": "Saved successfully!"
     },

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -140,7 +140,8 @@
         "formats": {
             "drawio": "Draw.io XML",
             "png": "PNG 画像",
-            "svg": "SVG 画像"
+            "svg": "SVG 画像",
+            "xmlsvg": "編集可能な SVG"
         },
         "savedSuccessfully": "保存完了！"
     },

--- a/lib/i18n/dictionaries/zh-Hant.json
+++ b/lib/i18n/dictionaries/zh-Hant.json
@@ -140,7 +140,8 @@
         "formats": {
             "drawio": "Draw.io XML",
             "png": "PNG 圖片",
-            "svg": "SVG 圖片"
+            "svg": "SVG 圖片",
+            "xmlsvg": "可編輯 SVG"
         },
         "savedSuccessfully": "儲存成功！"
     },

--- a/lib/i18n/dictionaries/zh.json
+++ b/lib/i18n/dictionaries/zh.json
@@ -140,7 +140,8 @@
         "formats": {
             "drawio": "Draw.io XML",
             "png": "PNG 图片",
-            "svg": "SVG 图片"
+            "svg": "SVG 图片",
+            "xmlsvg": "可编辑 SVG"
         },
         "savedSuccessfully": "保存成功！"
     },


### PR DESCRIPTION
Fixes #745

## Problem
The save dialog only offered 3 formats: `.drawio`, `.png`, and `.svg` (view-only). The `xmlsvg` format was used internally (for the `.drawio` export path) but never exposed to users. There was no way to export an editable SVG that embeds the draw.io XML, making it impossible to reopen and re-edit the file.

## Fix
Added `xmlsvg` as a 4th save format ("Editable SVG") with minimal changes across 3 areas:

- **`components/save-dialog.tsx`** — Added `"xmlsvg"` to the `ExportFormat` type and `FORMAT_OPTIONS` array
- **`contexts/diagram-context.tsx`** — Handled `xmlsvg` in `saveDiagramToFile`: uses the existing `xmlsvg` drawio export path but saves the raw SVG content (with embedded XML) instead of extracting the XML
- **`lib/i18n/dictionaries/*.json`** — Added label strings for all 4 locales: `"Editable SVG"` (en), `"可编辑 SVG"` (zh), `"編集可能な SVG"` (ja), `"可編輯 SVG"` (zh-Hant)

No new dependencies. The `xmlsvg` export format was already used internally throughout the codebase.

## Testing
- Open the save dialog → 4th option "Editable SVG" now appears
- Saving as Editable SVG produces a `.svg` file with embedded draw.io XML (`content` attribute on `<svg>`)
- The file can be reopened in draw.io and re-edited without losing diagram data
- Existing formats (`.drawio`, `.png`, `.svg`) are unaffected