### PR TITLE
fix: merge system messages for custom OpenAI-compatible endpoints

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -440,7 +440,12 @@ ${userInputText}
     // because open-source model chat templates (Qwen, Llama, etc.) typically reject multiple system messages
     const isCustomOpenAIEndpoint =
         resolvedProvider === "openai" &&
-        !!(baseUrl || process.env.OPENAI_BASE_URL)
+        !!(
+            baseUrl ||
+            process.env.OPENAI_BASE_URL ||
+            (serverModelConfig.baseUrlEnv &&
+                process.env[serverModelConfig.baseUrlEnv])
+        )
     const isSingleSystemProvider =
         SINGLE_SYSTEM_PROVIDERS.has(resolvedProvider) || isCustomOpenAIEndpoint
 


### PR DESCRIPTION
Fixes #734

## Problem

When using the OpenAI provider with a custom base URL (e.g., vLLM, LMStudio, or any self-hosted OpenAI-compatible server), the app sends **two system messages** to the API. Most open-source model chat templates (Qwen, Llama, etc.) enforce that system messages must appear exactly once at the beginning of the messages array, and reject duplicate system messages with the error:

```
TemplateError: System message must be at the beginning.
```

This affects users who:
- Deploy with `OPENAI_BASE_URL` environment variable pointing to vLLM/LMStudio
- Configure a custom base URL in the app settings with the OpenAI provider

## Solution

Detect when the OpenAI provider is used with a custom base URL (either via the `x-ai-base-url` client header or the `OPENAI_BASE_URL` environment variable) and treat it the same as other known single-system providers (MiniMax, GLM, Qwen, Kimi, etc.) — merging the two system messages into one before sending.

## Testing

- Configure `OPENAI_BASE_URL` pointing to a vLLM server serving Qwen or Llama models
- Send a chat message — the "System message must be at the beginning" error should no longer occur
- Existing OpenAI API users are unaffected (no custom base URL = behavior unchanged)