### PR TITLE
fix: zoom reset on drag and IndexedDB version conflict

### DIFF
--- a/contexts/diagram-context.tsx
+++ b/contexts/diagram-context.tsx
@@ -65,6 +65,10 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
         if (hasCalledOnLoadRef.current) return
         hasCalledOnLoadRef.current = true
         setIsDrawioReady(true)
+        // Restore diagram after remount (e.g., theme/UI change)
+        if (drawioRef.current && isRealDiagram(chartXMLRef.current)) {
+            drawioRef.current.load({ xml: chartXMLRef.current })
+        }
     }
 
     const resetDrawioReady = () => {
@@ -76,24 +80,6 @@ export function DiagramProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
         chartXMLRef.current = chartXML
     }, [chartXML])
-
-    // Restore diagram when DrawIO becomes ready after remount (e.g., theme/UI change)
-    // Also restore when chartXML changes while DrawIO is ready (e.g., session loaded after iframe ready)
-    const lastRestoredXmlRef = useRef<string>("")
-    useEffect(() => {
-        if (!isDrawioReady || !drawioRef.current) return
-        // Only load if we have a real diagram and it's different from what we already loaded
-        if (
-            isRealDiagram(chartXML) &&
-            chartXML !== lastRestoredXmlRef.current
-        ) {
-            lastRestoredXmlRef.current = chartXML
-            drawioRef.current.load({ xml: chartXML })
-        } else if (!isRealDiagram(chartXML)) {
-            // Reset when diagram is cleared so a future restore can re-load the same XML.
-            lastRestoredXmlRef.current = ""
-        }
-    }, [isDrawioReady, chartXML])
 
     // Track if we're expecting an export for file save (stores raw export data)
     const saveResolverRef = useRef<{

--- a/lib/template-storage.ts
+++ b/lib/template-storage.ts
@@ -2,8 +2,8 @@ import { type DBSchema, type IDBPDatabase, openDB } from "idb"
 import { nanoid } from "nanoid"
 
 // Constants
-const DB_NAME = "next-ai-drawio"
-const DB_VERSION = 2
+const DB_NAME = "next-ai-drawio-templates"
+const DB_VERSION = 1
 const STORE_NAME = "templates"
 
 // Types
@@ -34,14 +34,6 @@ export type TemplateCreateInput = Pick<Template, "prompt"> &
     >
 
 interface TemplateDB extends DBSchema {
-    sessions: {
-        key: string
-        value: {
-            id: string
-            [key: string]: unknown
-        }
-        indexes: { "by-updated": number }
-    }
     templates: {
         key: string
         value: Template
@@ -98,14 +90,6 @@ async function getDB(): Promise<IDBPDatabase<TemplateDB>> {
         dbPromise = openDB<TemplateDB>(DB_NAME, DB_VERSION, {
             upgrade(db, oldVersion) {
                 if (oldVersion < 1) {
-                    if (!db.objectStoreNames.contains("sessions")) {
-                        const sessionStore = db.createObjectStore("sessions", {
-                            keyPath: "id",
-                        })
-                        sessionStore.createIndex("by-updated", "updatedAt")
-                    }
-                }
-                if (oldVersion < 2) {
                     if (!db.objectStoreNames.contains(STORE_NAME)) {
                         const templateStore = db.createObjectStore(STORE_NAME, {
                             keyPath: "id",


### PR DESCRIPTION
## Summary

Fixes two bugs:

**1. Zoom resets when dragging items (#775)**

A `useEffect` in `diagram-context.tsx` watched `[isDrawioReady, chartXML]` and called `drawioRef.current.load()` whenever `chartXML` changed. Since every user edit (drag, move, type) triggers an autosave that updates `chartXML`, every edit caused a full diagram reload which reset the viewport/zoom. Fix: removed the useEffect and moved the restore logic into `onDrawioLoad` where it only fires on iframe remount (theme/dark mode change).

**2. IndexedDB VersionError breaking session storage**

`template-storage.ts` (from #773) opened the same IndexedDB (`"next-ai-drawio"`) at version 2, while `session-storage.ts` opens it at version 1. Once templates upgraded the DB to v2, all session operations failed with `VersionError`. Fix: give templates their own database (`"next-ai-drawio-templates"`).