### PR TITLE
fix: remove redundant status(modified:false) call after autosave to restore undo/redo

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -100,12 +100,8 @@ export default function Home() {
     const handleDrawioAutoSave = useCallback(
         (data: { xml?: string }) => {
             handleDiagramAutoSave(data)
-            // Only suppress modified state when persistence is available
-            if (canPersist) {
-                drawioRef.current?.status({ message: "", modified: false })
-            }
         },
-        [canPersist, drawioRef, handleDiagramAutoSave],
+        [handleDiagramAutoSave],
     )
 
     const handleDarkModeChange = () => {


### PR DESCRIPTION
Fixes #779

## Problem

Undo and Redo buttons in the draw.io editor toolbar were always disabled
(grayed out) after diagram operations.

There were two causes:

1. **Primary cause (fixed in #776)**: A `useEffect` in
   `diagram-context.tsx` called `drawioRef.current.load()` on every
   autosave-triggered `chartXML` state change. The `load()` action
   resets draw.io's internal undo history, so every user operation
   (shape drawn → autosave) immediately cleared undo. This was fixed
   in #776 by removing the effect and moving restore logic to
   `onDrawioLoad`.

2. **Secondary cause (this PR)**: `handleDrawioAutoSave` in `page.tsx`
   was sending `status({ message: "", modified: false })` to draw.io
   after every autosave event when `canPersist` is true. This call is
   redundant because `keepmodified: false` is already passed as a URL
   parameter, which instructs draw.io to clear the modified flag
   automatically after autosave. The redundant `status` message could
   interfere with draw.io's toolbar state refresh, potentially
   disabling the Undo/Redo buttons even when history entries exist.

## Solution

Remove the redundant `drawioRef.current?.status({ message: "", modified: false })`
call. The `keepmodified: false` URL parameter already handles clearing
the modified indicator after autosave without any side effects on the
undo/redo toolbar state.

## Testing

1. Open the app
2. Draw shapes or move elements on the canvas
3. Verify the Undo button in the draw.io toolbar becomes enabled
4. Press Ctrl+Z — confirm the last operation is undone
5. Press Ctrl+Shift+Z or click Redo — confirm the operation is redone