### PR TITLE
fix: allow Qwen3.5 models to use image input

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1356,12 +1356,11 @@ export function supportsImageInput(modelId: string): boolean {
     }
 
     // Qwen text models (not vision variants like qwen-vl)
-    // qwen3.5-plus is a vision model
+    // Qwen3.5 series (qwen3.5, qwen3.5-plus, qwen3.5-flash) natively support image input
     if (
         lowerModelId.includes("qwen") &&
         !hasVisionIndicator &&
-        !lowerModelId.includes("qwen3.5-plus") &&
-        !lowerModelId.includes("qwen3.5-flash")
+        !lowerModelId.includes("qwen3.5")
     ) {
         return false
     }

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -200,6 +200,8 @@ describe("supportsImageInput", () => {
 
     it("returns true for Qwen vision models", () => {
         expect(supportsImageInput("qwen-vl")).toBe(true)
+        expect(supportsImageInput("Qwen3.5")).toBe(true)
+        expect(supportsImageInput("qwen3.5")).toBe(true)
         expect(supportsImageInput("qwen3.5-plus")).toBe(true)
         expect(supportsImageInput("qwen3.5-flash")).toBe(true)
         expect(supportsImageInput("qwen3-vl-plus")).toBe(true)


### PR DESCRIPTION
Fixes #799

## Problem

When using a locally deployed Qwen3.5 model via vLLM (which natively supports image input), attaching an image in the chat returns:

```
{"error":"The model \"Qwen3.5\" does not support image input. Please use a vision-capable model (e.g., GPT-4o, Claude, Gemini) or remove the image."}
```

This is a false negative in `supportsImageInput()` in `lib/ai-providers.ts`. The function exempts `qwen3.5-plus` and `qwen3.5-flash` as vision-capable, but not the base `qwen3.5` model name.

## Solution

Simplify the Qwen exception from two separate suffix checks to a single `qwen3.5` substring check. Since `"qwen3.5"` is a common prefix of all three variants (`qwen3.5`, `qwen3.5-plus`, `qwen3.5-flash`), this covers all of them with less code.

```diff
-    !lowerModelId.includes("qwen3.5-plus") &&
-    !lowerModelId.includes("qwen3.5-flash")
+    !lowerModelId.includes("qwen3.5")
```

Older Qwen text-only models (`qwen-turbo`, `qwen-plus`, `qwen3-max`, etc.) are still correctly blocked.

## Testing

- Added `supportsImageInput("Qwen3.5")` and `supportsImageInput("qwen3.5")` to the existing unit test suite.
- Existing tests for `qwen3.5-plus`, `qwen3.5-flash`, text-only Qwen models, and vision-indicator models remain passing.