### PR TITLE
fix: improve create_new_diagram tool description to prevent misuse

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.17",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@next-ai-drawio/mcp-server",
-            "version": "0.1.17",
+            "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.4",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@next-ai-drawio/mcp-server",
-    "version": "0.1.19",
+    "version": "0.2.0",
     "description": "MCP server for Next AI Draw.io - AI-powered diagram generation with real-time browser preview",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -155,19 +155,22 @@ server.registerTool(
 server.registerTool(
     "create_new_diagram",
     {
-        description: `Create a NEW diagram from mxGraphModel XML. Use this when creating a diagram from scratch or replacing the current diagram entirely.
+        description: `Create a NEW diagram from mxGraphModel XML. ONLY use this when creating a diagram from scratch.
+
+⚠️ DO NOT use this tool to modify an existing diagram — it will DESTROY all existing content and user changes. Use edit_diagram instead for ANY modifications to an existing diagram.
 
 CRITICAL: You MUST provide the 'xml' argument in EVERY call. Do NOT call this tool without xml.
 
 When to use this tool:
-- Creating a new diagram from scratch
-- Replacing the current diagram with a completely different one
-- Major structural changes that require regenerating the diagram
+- Creating a new diagram from scratch (no existing diagram)
+- The user explicitly asks to "start over" or "create a new diagram"
 
-When to use edit_diagram instead:
-- Small modifications to existing diagram
-- Adding/removing individual elements
-- Changing labels, colors, or positions
+When to use edit_diagram instead (ALWAYS prefer edit_diagram if a diagram already exists):
+- ANY modifications to an existing diagram
+- Adding/removing/moving elements
+- Changing labels, colors, styles, or positions
+- Restructuring or reorganizing existing content
+- Adding new elements to an existing diagram
 
 XML FORMAT - Full mxGraphModel structure:
 <mxGraphModel>

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -12,7 +12,8 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["node"]
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- Updated `create_new_diagram` tool description to explicitly warn that it destroys existing content, steering AI to use `edit_diagram` instead for modifications
- Removed the "major structural changes" escape hatch that gave AI justification to bypass `edit_diagram`
- Added `types: ["node"]` to tsconfig.json to fix IDE lint errors
- Bumped version to v0.2.0 (already published to npm)