### PR TITLE
feat: add rpm target for Linux distribution

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -95,6 +95,10 @@ linux:
       arch:
         - x64
         - arm64
+    - target: rpm
+      arch:
+        - x64
+        - arm64
 
 # Publish configuration (optional)
 publish:


### PR DESCRIPTION
## Summary
- Add `rpm` target (x64 + arm64) to `electron-builder.yml` for Linux RPM package distribution

## Test plan
- [x] Verified RPM builds successfully locally (`next-ai-draw-io-0.4.14.x86_64.rpm` generated)
- [x] No CI changes needed — `npm run dist:linux` in electron-release workflow automatically picks up new target

🤖 Generated with [Claude Code](https://claude.com/claude-code)