### PR TITLE
fix: prevent infinite auto-retry loop after max retries are reached

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -272,6 +272,10 @@ export default function ChatPanel({
     const autoRetryCountRef = useRef(0)
     // Ref to track continuation retry count (for truncation handling)
     const continuationRetryCountRef = useRef(0)
+    // Ref to permanently block auto-retry after limit is reached until user sends new message.
+    // This prevents the retry counter from being reset mid-stream (when hasToolErrors briefly
+    // returns false during streaming) and immediately restarting the retry cycle.
+    const retryExhaustedRef = useRef(false)
 
     // Ref to accumulate partial XML when output is truncated due to maxOutputTokens
     // When partialXmlRef.current.length > 0, we're in continuation mode
@@ -451,6 +455,15 @@ export default function ChatPanel({
         },
         onFinish: () => {},
         sendAutomaticallyWhen: ({ messages }) => {
+            // If the retry limit was already hit for this user turn, block all
+            // further auto-sends until the user explicitly sends a new message.
+            // This prevents the retry cycle from restarting after the counter is
+            // reset mid-stream (when hasToolErrors briefly returns false during
+            // streaming of the retry response).
+            if (retryExhaustedRef.current) {
+                return false
+            }
+
             const isInContinuationMode = partialXmlRef.current.length > 0
 
             const shouldRetry = hasToolErrors(
@@ -458,9 +471,12 @@ export default function ChatPanel({
             )
 
             if (!shouldRetry) {
-                // No error, reset retry count and clear state
-                autoRetryCountRef.current = 0
-                continuationRetryCountRef.current = 0
+                // No tool errors — clear continuation state but do NOT reset
+                // autoRetryCountRef here. Resetting it mid-stream (while the AI
+                // is still generating a retry response) would allow the counter
+                // to restart from zero and bypass the MAX_AUTO_RETRY_COUNT limit.
+                // The counter is reset in sendChatMessage when the user explicitly
+                // initiates a new message.
                 partialXmlRef.current = ""
                 return false
             }
@@ -476,7 +492,7 @@ export default function ChatPanel({
                             max: MAX_CONTINUATION_RETRY_COUNT,
                         }),
                     )
-                    continuationRetryCountRef.current = 0
+                    retryExhaustedRef.current = true
                     partialXmlRef.current = ""
                     return false
                 }
@@ -489,7 +505,7 @@ export default function ChatPanel({
                             max: MAX_AUTO_RETRY_COUNT,
                         }),
                     )
-                    autoRetryCountRef.current = 0
+                    retryExhaustedRef.current = true
                     partialXmlRef.current = ""
                     return false
                 }
@@ -1062,6 +1078,7 @@ export default function ChatPanel({
         // Reset all retry/continuation state on user-initiated message
         autoRetryCountRef.current = 0
         continuationRetryCountRef.current = 0
+        retryExhaustedRef.current = false
         partialXmlRef.current = ""
 
         const config = getSelectedAIConfig()


### PR DESCRIPTION
## Problem

Fixes #455

The `sendAutomaticallyWhen` callback in `chat-panel.tsx` enters an infinite retry cycle even though `MAX_AUTO_RETRY_COUNT = 3` is enforced. Users reported the app keeps retrying indefinitely after tool call failures, causing visible UI hangs and flooding the API with repeated requests.

Root cause is a two-part issue in the counter logic:

**1. Counter reset after limit hit:**
After reaching the retry limit and displaying the toast, `autoRetryCountRef.current` was reset to `0`. On the very next call to `sendAutomaticallyWhen` (triggered by the same errored messages still in the list), the callback sees `count = 0` and starts the retry cycle all over again — indefinitely.

**2. Counter reset during streaming:**
While a retry response is streaming, `hasToolErrors` momentarily returns `false` because the new streaming message has tool parts in `"input-streaming"` state (not `"output-error"` yet). This caused `autoRetryCountRef.current` to reset to `0`. When the streamed response eventually produces a tool error, the counter looks fresh and the cycle restarts.

## Fix

Introduce `retryExhaustedRef` — a boolean flag that is set to `true` when the retry limit is hit. `sendAutomaticallyWhen` returns `false` immediately if the flag is set, blocking all further auto-sends for that user turn. The flag is cleared in `sendChatMessage` when the user explicitly initiates a new message, giving the next turn a fresh retry quota.

Also removed the premature counter resets in the `shouldRetry === false` branch — the counters should only reset when the user sends a new message, not mid-stream when the callback sees a momentary non-error state.

## Changes

- `components/chat-panel.tsx`: Add `retryExhaustedRef`, guard `sendAutomaticallyWhen` with early-return, fix counter reset timing, reset flag in `sendChatMessage`

## Testing

The fix can be verified by:
1. Configuring a model that consistently fails tool calls
2. Sending a message that triggers diagram tool use
3. Confirming the error toast appears after exactly 3 retries and no further retries occur
4. Sending a new message confirms the retry quota resets correctly for the new turn