### PR TITLE
fix: allow QvQ (Qwen Visual QA) models to use image input

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1357,10 +1357,12 @@ export function supportsImageInput(modelId: string): boolean {
 
     // Qwen text models (not vision variants like qwen-vl)
     // Qwen3.5 series (qwen3.5, qwen3.5-plus, qwen3.5-flash) natively support image input
+    // QvQ (Qwen Visual QA) models are vision models — exclude them even when prefixed with "qwen/"
     if (
         lowerModelId.includes("qwen") &&
         !hasVisionIndicator &&
-        !lowerModelId.includes("qwen3.5")
+        !lowerModelId.includes("qwen3.5") &&
+        !lowerModelId.includes("qvq")
     ) {
         return false
     }

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -208,6 +208,13 @@ describe("supportsImageInput", () => {
         expect(supportsImageInput("qwen3-vl-flash")).toBe(true)
     })
 
+    it("returns true for QvQ (Qwen Visual QA) models including OpenRouter-prefixed names", () => {
+        expect(supportsImageInput("qvq-72b-preview")).toBe(true)
+        expect(supportsImageInput("qvq-max")).toBe(true)
+        expect(supportsImageInput("qwen/qvq-72b-preview")).toBe(true)
+        expect(supportsImageInput("qwen/qvq-max")).toBe(true)
+    })
+
     it("returns false for GLM text models", () => {
         expect(supportsImageInput("glm-4")).toBe(false)
         expect(supportsImageInput("glm-4-plus")).toBe(false)


### PR DESCRIPTION
## Problem

QvQ (Qwen Visual QA) models such as `qvq-72b-preview` and `qvq-max` are vision-capable models from the Qwen family. When accessed via providers that prefix model names with `qwen/` (e.g., OpenRouter uses `qwen/qvq-72b-preview`), the model ID contains `qwen` but lacks a `vl` or `vision` suffix.

This caused `supportsImageInput()` to incorrectly return `false` for these model IDs, blocking image attachments even though the model fully supports vision input.

The issue does **not** affect direct Ollama usage (e.g., `qvq-72b-preview`) since those IDs don't include the `qwen/` prefix, but it does affect users accessing QvQ via OpenRouter or any other provider that uses the `qwen/` namespace.

## Solution

Add `qvq` as an explicit exception in the Qwen text-model check inside `supportsImageInput()`, similar to how `qwen3.5` was already exempted. This ensures `qwen/qvq-72b-preview` (and any future `qwen/qvq-*` variants) are correctly allowed to receive image input.

## Testing

Added unit tests covering:
- `qvq-72b-preview` — direct access (already worked, now explicitly tested)
- `qvq-max` — direct access
- `qwen/qvq-72b-preview` — OpenRouter-style prefix (was broken, now fixed)
- `qwen/qvq-max` — OpenRouter-style prefix (was broken, now fixed)