### PR TITLE
fix: use createAzure in validate-model and fix resourceName fallback

### DIFF
--- a/app/api/validate-model/route.ts
+++ b/app/api/validate-model/route.ts
@@ -4,6 +4,7 @@ import { createDeepSeek, deepseek } from "@ai-sdk/deepseek"
 import { createGateway } from "@ai-sdk/gateway"
 import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { createVertex } from "@ai-sdk/google-vertex"
+import { createAzure } from "@ai-sdk/azure"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import { generateText } from "ai"
@@ -126,11 +127,11 @@ export async function POST(req: Request) {
             }
 
             case "azure": {
-                const azure = createOpenAI({
+                const azureClient = createAzure({
                     apiKey,
-                    baseURL: baseUrl,
+                    ...(baseUrl && { baseURL: baseUrl }),
                 })
-                model = azure.chat(modelId)
+                model = azureClient(modelId)
                 break
             }
 

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -913,10 +913,10 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
                 overrides?.baseUrl,
                 serverBaseUrl,
             )
-            // Only use server's resourceName if user is NOT providing their own API key
-            const resourceName = overrides?.apiKey
-                ? undefined
-                : process.env.AZURE_RESOURCE_NAME
+            // Only use server's resourceName when no baseURL is available.
+            // resourceName is an endpoint component (not a credential), so it is
+            // safe to use as a fallback even when the user brings their own API key.
+            const resourceName = !baseURL ? process.env.AZURE_RESOURCE_NAME : undefined
             // Azure requires either baseURL or resourceName to construct the endpoint
             // resourceName constructs: https://{resourceName}.openai.azure.com/openai/v1{path}
             if (baseURL || resourceName || overrides?.apiKey) {


### PR DESCRIPTION
Fixes #819

## Problem

Two related bugs caused Azure OpenAI to pass validation but fail during actual use with a \"resource cannot be found\" error:

1. **Inconsistent SDK in validation**: `validate-model/route.ts` used `createOpenAI` for the Azure provider, while `ai-providers.ts` uses `createAzure`. These two SDKs differ in how they construct the endpoint URL and authenticate (`Authorization: Bearer` vs `api-key` header). Validation passed against a working Azure endpoint, but the actual model call used a different code path and could fail.

2. **Missing endpoint when user provides only an API key**: In `ai-providers.ts`, when a user configured their own Azure API key without a custom base URL, `resourceName` was unconditionally set to `undefined`. This left `createAzure` with only `{ apiKey }` and no endpoint information, causing the Azure SDK to call an incorrect or empty URL.

## Solution

- **`validate-model/route.ts`**: Switch the Azure case from `createOpenAI` to `createAzure`, matching the SDK used for real model calls.
- **`lib/ai-providers.ts`**: Change `resourceName` assignment to fall back to `AZURE_RESOURCE_NAME` from the environment whenever no `baseURL` is available. `resourceName` is an endpoint component (not a credential), so this is safe regardless of whether the user supplies their own API key.

## Testing

- Configured Azure OpenAI with an API key and no custom base URL (server has `AZURE_RESOURCE_NAME` set) — endpoint now resolves correctly.
- Configured Azure OpenAI with an API key and a custom base URL — `baseURL` still takes precedence, `resourceName` is `undefined` as expected.
- Validation now uses the same `createAzure` SDK as actual model calls, ensuring validation failures are consistent with runtime failures.