### PR TITLE
chore: align biome schema version with CLI latest

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/electron/electron.d.ts
+++ b/electron/electron.d.ts
@@ -101,8 +101,8 @@ declare global {
 }
 
 export type {
-    ConfigPreset,
     ApplyPresetResult,
+    ConfigPreset,
     ProxyConfig,
     SetProxyResult,
     SetUserLocaleResult,


### PR DESCRIPTION
## Summary
- Bumps `biome.json` `\$schema` from `2.4.4` → `2.4.14` so the repo schema matches what the `Auto Format` workflow installs via `@biomejs/biome@latest`.
- Applies the one auto-fix the newer Biome produces: alphabetical `export type` ordering in `electron/electron.d.ts`.

## Why
The `Auto Format` workflow runs `npx @biomejs/biome@latest check --write .`. Because the repo schema was pinned to an older version, every fork PR tripped the `Fail if fork PR needs formatting` step even when the PR itself was clean (e.g. #818's 1-line CSS fix).

## Test plan
- [ ] `Auto Format` job passes on this PR
- [ ] Local `npx @biomejs/biome@latest check .` reports no fixable issues (only the 3 pre-existing `useOptionalChain` warnings, which are unsafe-fix only)