### PR TITLE
fix(electron): override draw.io iframe beforeunload to allow window close (#815)

### DIFF
--- a/electron/main/window-manager.ts
+++ b/electron/main/window-manager.ts
@@ -60,6 +60,13 @@ export function createWindow(serverUrl: string): BrowserWindow {
         mainWindow.webContents.openDevTools()
     }
 
+    // Override the draw.io iframe's beforeunload handler so the window can
+    // close after the user edits text in a shape (fixes #815). Diagrams are
+    // already persisted via autosave, so the prompt is unnecessary.
+    mainWindow.webContents.on("will-prevent-unload", (event) => {
+        event.preventDefault()
+    })
+
     mainWindow.on("closed", () => {
         mainWindow = null
     })


### PR DESCRIPTION
## Summary

#815 — on Windows and macOS, the Electron window cannot be closed after the user types text into a shape (and sometimes simply edits the diagram). Affects clicking the close button, Cmd/Ctrl+Q, and the application menu Quit.

Five prior PRs (#123, #573, #642, #648, #780) attempted fixes that did not address the root cause. This PR is a 1-line Electron-side fix.

## Root cause

draw.io's bundled `EditorUi` unconditionally registers `window.onbeforeunload`. In embed mode, when `editor.modified === true` (which happens after any edit, including entering text on a shape), the handler returns the string `'allChangesLost'`.

Per Electron's [`BrowserWindow` docs](https://www.electronjs.org/docs/latest/api/browser-window#event-close):

> "In Electron, returning any value other than `undefined` would cancel the close. … Unlike usual browsers that a message box will be prompted to users, **returning a non-void value will silently cancel the close**."

Because no handler in the main process intercepted this, every close attempt was silently cancelled — no dialog, just nothing. None of the prior PRs targeted the main process; they all tried to suppress the iframe's beforeunload from the renderer side, which doesn't work because:

- `confirmExit` is not a real draw.io configuration option (verified — zero matches in `jgraph/drawio` source).
- `modified=0` / `keepmodified=0` URL params only affect the status-bar display and the post-save modified-flag clearing — they do not prevent edits from setting `editor.modified=true`.
- The `status({modified:false})` workaround from #642 broke undo/redo (#779), and was reverted by #780.

## Fix

Call `event.preventDefault()` in `will-prevent-unload`. Per [Electron's docs](https://www.electronjs.org/docs/latest/api/web-contents#event-will-prevent-unload):

> "Calling `event.preventDefault()` will ignore the `beforeunload` event handler and allow the page to be unloaded."

This is the documented, supported way to override beforeunload prompts in Electron.

## Why this is safe

- The host app already persists diagrams via `autosave` → IndexedDB, plus a `visibilitychange` handler that flushes session state when the window is hidden. The prompt was redundant.
- PR #573 already removed the renderer-side close-protection feature explicitly because the project does not want a "are you sure?" dialog.
- The fix only affects window-close behavior; no other surfaces use `will-prevent-unload`.

## Test plan

- [x] Reproduce the bug locally on macOS arm64 with the released v0.4.15 dmg: drew a shape, double-clicked to enter text mode, clicked X — window refused to close. Cmd+Q also refused.
- [x] Apply the fix in dev mode (`npm run electron:dev`), repeat the same steps — window closes immediately on click.
- [x] Verified via diagnostic logging that `will-prevent-unload` was firing on every close attempt before the fix (with `defaultPrevented=false`), and that calling `preventDefault()` lets the close pipeline complete (`window 'closed' event fired`).
- [ ] Verify on Windows 10 22H2 (the OS originally reported in #815).
- [ ] Verify undo/redo still works (#779 should not regress — this fix doesn't touch the renderer).

## Follow-up

A separate PR will remove the now-unused renderer-side workarounds added by #642 (`canPersist` state + `confirmExit` config + `modified=0` / `keepmodified=0` URL params + `isIndexedDBUsable` async probe).