### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/cn/ai-providers.md
+++ b/docs/cn/ai-providers.md
@@ -215,7 +215,7 @@ MiniMax 支持两种 API 格式：
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.7
+AI_MODEL=MiniMax-M3
 ```
 
 可选配置：

--- a/docs/en/ai-providers.md
+++ b/docs/en/ai-providers.md
@@ -230,7 +230,7 @@ MiniMax supports two API formats:
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.7
+AI_MODEL=MiniMax-M3
 ```
 
 Optional configuration:

--- a/docs/ja/ai-providers.md
+++ b/docs/ja/ai-providers.md
@@ -215,7 +215,7 @@ MiniMax は 2 つの API 形式をサポートしています：
 
 ```bash
 MINIMAX_API_KEY=your_api_key
-AI_MODEL=MiniMax-M2.7
+AI_MODEL=MiniMax-M3
 ```
 
 オプション設定：

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1361,8 +1361,12 @@ export function supportsImageInput(modelId: string): boolean {
         return false
     }
 
-    // MiniMax text models (MiniMax-M2.x series are text-only)
-    if (lowerModelId.includes("minimax") && !hasVisionIndicator) {
+    // MiniMax text models (MiniMax-M2.x series are text-only; M3 supports image input)
+    if (
+        lowerModelId.includes("minimax") &&
+        !hasVisionIndicator &&
+        !lowerModelId.includes("m3")
+    ) {
         return false
     }
 

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -351,10 +351,9 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
     ],
     minimax: [
         // MiniMax models (Anthropic-compatible API)
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
     ],
     novita: [
         // Novita AI models (OpenAI-compatible API)

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -180,11 +180,14 @@ describe("supportsImageInput", () => {
         expect(supportsImageInput("moonshot-v1-128k")).toBe(false)
     })
 
-    it("returns false for MiniMax text models", () => {
+    it("returns false for MiniMax M2 text models", () => {
         expect(supportsImageInput("MiniMax-M2.7")).toBe(false)
-        expect(supportsImageInput("MiniMax-M2.5")).toBe(false)
+        expect(supportsImageInput("MiniMax-M2.7-highspeed")).toBe(false)
         expect(supportsImageInput("MiniMax-M2")).toBe(false)
-        expect(supportsImageInput("MiniMax-M2.5-highspeed")).toBe(false)
+    })
+
+    it("returns true for MiniMax M3 (supports image input)", () => {
+        expect(supportsImageInput("MiniMax-M3")).toBe(true)
     })
 
     it("returns false for DeepSeek text models", () => {


### PR DESCRIPTION
## Summary
Upgrade the MiniMax model lineup to include the latest M3 model as the default suggestion.

## Changes
- Add `MiniMax-M3` to the suggested model list (set as new default, listed first)
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` from the suggested list
- Update `supportsImageInput`: M2.x are still text-only, M3 supports image input
- Update unit tests to reflect the new lineup (text-only assertions for M2 series, image-input assertion for M3)
- Update `AI_MODEL` example in the CN / EN / JA AI provider docs to `MiniMax-M3`

## Why
`MiniMax-M3` is the new flagship MiniMax model with a 512K context window, 128K max output, and image-input support across both OpenAI- and Anthropic-compatible interfaces. Older M2.5 / M2.5-highspeed have been superseded; M2.7 / M2.7-highspeed are kept so existing users still see their current default.

## Testing
- `npx vitest run` — 105/105 unit tests pass
- `npx tsc --noEmit` — clean
- `npx biome check` — no new errors on changed files