### PR TITLE
fix(deps): bump @ai-sdk/amazon-bedrock to fix Bedrock tool streaming under Zod v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "next-ai-draw-io",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "next-ai-draw-io",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/amazon-bedrock": "^4.0.1",
@@ -122,17 +122,79 @@
             "license": "MIT"
         },
         "node_modules/@ai-sdk/amazon-bedrock": {
-            "version": "4.0.64",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.64.tgz",
-            "integrity": "sha512-foZskBdIHPGPZLfEKqkOP18JgfMy5Duik1TTduvEQ97mX3yfEzr4go1V3oU7ktry0dAL5BiNY38WwRhl+xhy9g==",
+            "version": "4.0.113",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.113.tgz",
+            "integrity": "sha512-qoeF2ghkYqHY4u68rasZopYsRuGnRwgqSfe6rhC/jM6W73Z7TU5v9QcfDYKt9dgp19YHY9EqiX3SXVC+uPGkRQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/anthropic": "3.0.47",
-                "@ai-sdk/provider": "3.0.8",
-                "@ai-sdk/provider-utils": "4.0.15",
+                "@ai-sdk/anthropic": "3.0.81",
+                "@ai-sdk/openai": "3.0.68",
+                "@ai-sdk/provider": "3.0.10",
+                "@ai-sdk/provider-utils": "4.0.27",
                 "@smithy/eventstream-codec": "^4.0.1",
                 "@smithy/util-utf8": "^4.0.0",
                 "aws4fetch": "^1.0.20"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/anthropic": {
+            "version": "3.0.81",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.81.tgz",
+            "integrity": "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.10",
+                "@ai-sdk/provider-utils": "4.0.27"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/openai": {
+            "version": "3.0.68",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.68.tgz",
+            "integrity": "sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.10",
+                "@ai-sdk/provider-utils": "4.0.27"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+            "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider-utils": {
+            "version": "4.0.27",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+            "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.10",
+                "@standard-schema/spec": "^1.1.0",
+                "eventsource-parser": "^3.0.8"
             },
             "engines": {
                 "node": ">=18"
@@ -2243,9 +2305,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -2263,9 +2322,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -2283,9 +2339,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -2303,9 +2356,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -4898,9 +4948,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4916,9 +4963,6 @@
             "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4936,9 +4980,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4954,9 +4995,6 @@
             "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -8304,9 +8342,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -13936,9 +13971,9 @@
             "license": "MIT"
         },
         "node_modules/eventsource-parser": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+            "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -16613,9 +16648,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -16799,9 +16831,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -16822,9 +16851,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -16844,9 +16870,6 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,


### PR DESCRIPTION
## Summary
- Refreshes the lockfile to pull `@ai-sdk/amazon-bedrock` to `4.0.113` (was pinned at `4.0.64`; the existing `^4.0.1` range already permits this).
- #859: tool calls failed with `Invalid input: expected nonoptional, received undefined` at `contentBlockStart.start.toolUse.input` whenever a Bedrock Claude model with the `fine-grained-tool-streaming-2025-05-14` beta tried to call any tool.

## Root cause
`@ai-sdk/amazon-bedrock@4.0.64` declared `input: z.unknown()` on `BedrockToolUseSchema`. Under Zod v4 (which the SDK uses), `z.unknown()` on an object key is non-optional, so the missing `input` in Bedrock's streaming `contentBlockStart` event tripped validation. Upstream `4.0.101` fixed this by marking `input` optional on the streaming tool-use schema. No source code in this repo needed to change.
