### PR TITLE
ci: pin Biome to 2.4.13 in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -23,7 +23,9 @@ jobs:
           node-version: '24'
 
       - name: Run Biome format
-        run: npx @biomejs/biome@latest check --write --no-errors-on-unmatched .
+        # Pin to the version in package.json so CI matches local/pre-commit
+        # (npx @latest drifts — e.g. 2.5.0 broke this job on unrelated PRs).
+        run: npx @biomejs/biome@2.4.13 check --write --no-errors-on-unmatched .
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Problem

The `Auto Format` workflow runs `npx @biomejs/biome@latest`, which is unpinned. `latest` recently advanced to **2.5.0**, which:

- deprecates config fields (`recommended` → `preset`) and tightens schema-version checks against `biome.json` (declared 2.4.x)
- parses existing files more strictly (e.g. `public/resnet50.svg`), producing 86 errors → the job exits 1

This made the format job fail on PRs that changed nothing related to formatting (it broke #866). Historically the job passed only because `latest` happened to be 2.4.x at the time — a version-drift time bomb.

## Fix

Pin the workflow to `@biomejs/biome@2.4.13`, matching the version already in `package.json` (used by local dev and the pre-commit hook). Now all three — local, pre-commit, and CI — run the same version.

## Verification

`npx @biomejs/biome@2.4.13 check --write --no-errors-on-unmatched .` on the full repo: 0 errors (8 warnings, 2 infos), no files modified → the format job passes with no auto-format commit.

## Note

Upgrading to 2.5.0 is fine but is a separate, deliberate change (run `biome migrate`, handle the 86 pre-existing errors, bump all three version references together) — out of scope here.