### PR TITLE
[codex] fix: block private IPv6 URLs in SSRF checks

### DIFF
--- a/lib/ssrf-protection.ts
+++ b/lib/ssrf-protection.ts
@@ -11,7 +11,10 @@ export function isPrivateUrl(urlString: string): boolean {
         const url = new URL(urlString)
         // Strip a trailing dot so FQDN forms like "localhost." (which still
         // resolve to 127.0.0.1) cannot bypass the equality checks below.
-        const hostname = url.hostname.toLowerCase().replace(/\.$/, "")
+        const hostname = url.hostname
+            .toLowerCase()
+            .replace(/^\[|\]$/g, "")
+            .replace(/\.$/, "")
 
         // Block localhost
         if (
@@ -20,6 +23,19 @@ export function isPrivateUrl(urlString: string): boolean {
             hostname === "::1"
         ) {
             return true
+        }
+
+        // Block IPv6 loopback, unique-local, link-local, and IPv4-mapped hosts.
+        if (hostname.includes(":")) {
+            if (
+                hostname === "0:0:0:0:0:0:0:1" ||
+                hostname.startsWith("fc") ||
+                hostname.startsWith("fd") ||
+                hostname.startsWith("fe80:") ||
+                hostname.startsWith("::ffff:")
+            ) {
+                return true
+            }
         }
 
         // Block AWS/cloud metadata endpoints

--- a/lib/ssrf-protection.ts
+++ b/lib/ssrf-protection.ts
@@ -20,21 +20,26 @@ export function isPrivateUrl(urlString: string): boolean {
         if (
             hostname === "localhost" ||
             hostname === "127.0.0.1" ||
-            hostname === "::1"
+            hostname === "::1" ||
+            hostname === "::"
         ) {
             return true
         }
 
-        // Block IPv6 loopback, unique-local, link-local, and IPv4-mapped hosts.
+        // Block IPv6 unique-local (fc00::/7), link-local (fe80::/10),
+        // and IPv4-mapped (::ffff:0:0/96) hosts.
         if (hostname.includes(":")) {
             if (
-                hostname === "0:0:0:0:0:0:0:1" ||
                 hostname.startsWith("fc") ||
                 hostname.startsWith("fd") ||
-                hostname.startsWith("fe80:") ||
                 hostname.startsWith("::ffff:")
             ) {
                 return true
+            }
+            const linkLocal = hostname.match(/^fe([0-9a-f]{2}):/)
+            if (linkLocal) {
+                const high = parseInt(linkLocal[1], 16)
+                if (high >= 0x80 && high <= 0xbf) return true
             }
         }
 

--- a/tests/unit/ssrf-protection.test.ts
+++ b/tests/unit/ssrf-protection.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { isPrivateUrl } from "@/lib/ssrf-protection"
+
+describe("isPrivateUrl", () => {
+    it("blocks private IPv6 URLs", () => {
+        expect(isPrivateUrl("http://[::1]/")).toBe(true)
+        expect(isPrivateUrl("http://[0:0:0:0:0:0:0:1]/")).toBe(true)
+        expect(isPrivateUrl("http://[::ffff:127.0.0.1]/")).toBe(true)
+        expect(isPrivateUrl("http://[fc00::1]/")).toBe(true)
+        expect(isPrivateUrl("http://[fd12:3456:789a::1]/")).toBe(true)
+        expect(isPrivateUrl("http://[fe80::1]/")).toBe(true)
+    })
+
+    it("allows public URLs", () => {
+        expect(isPrivateUrl("https://example.com/article")).toBe(false)
+        expect(isPrivateUrl("https://fc00.example.com/article")).toBe(false)
+    })
+})

--- a/tests/unit/ssrf-protection.test.ts
+++ b/tests/unit/ssrf-protection.test.ts
@@ -5,10 +5,13 @@ describe("isPrivateUrl", () => {
     it("blocks private IPv6 URLs", () => {
         expect(isPrivateUrl("http://[::1]/")).toBe(true)
         expect(isPrivateUrl("http://[0:0:0:0:0:0:0:1]/")).toBe(true)
+        expect(isPrivateUrl("http://[::]/")).toBe(true)
         expect(isPrivateUrl("http://[::ffff:127.0.0.1]/")).toBe(true)
         expect(isPrivateUrl("http://[fc00::1]/")).toBe(true)
         expect(isPrivateUrl("http://[fd12:3456:789a::1]/")).toBe(true)
         expect(isPrivateUrl("http://[fe80::1]/")).toBe(true)
+        expect(isPrivateUrl("http://[fe9f::1]/")).toBe(true)
+        expect(isPrivateUrl("http://[febf::1]/")).toBe(true)
     })
 
     it("allows public URLs", () => {


### PR DESCRIPTION
## Summary

- normalize bracketed IPv6 hostnames before SSRF checks
- block IPv6 loopback/unspecified, unique-local, link-local, and IPv4-mapped private hosts
- add unit coverage for private IPv6 URLs and public hostname false positives

## Why

The existing SSRF guard handled private IPv4 and internal hostnames, but bracketed IPv6 literals could bypass those checks. This keeps the existing small guard and fills the IPv6 private-address gap.

## Validation

- `npm test -- --run tests/unit/ssrf-protection.test.ts`
- `npm test -- --run`
- `npm run check` exits 0; it still reports existing Biome warnings/schema info outside this diff
- `git diff --check`