### PR TITLE
fix: remove name-based image-input detection (#874)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,7 +15,6 @@ import { z } from "zod"
 import {
     getAIModel,
     SINGLE_SYSTEM_PROVIDERS,
-    supportsImageInput,
     supportsPromptCaching,
 } from "@/lib/ai-providers"
 import { findCachedResponse } from "@/lib/cached-responses"
@@ -266,16 +265,10 @@ async function handleChatRequest(req: Request): Promise<Response> {
         lastUserMessage?.parts?.filter((part: any) => part.type === "file") ||
         []
 
-    // Check if user is sending images to a model that doesn't support them
-    // AI SDK silently drops unsupported parts, so we need to catch this early
-    if (fileParts.length > 0 && !supportsImageInput(modelId)) {
-        return Response.json(
-            {
-                error: `The model "${modelId}" does not support image input. Please use a vision-capable model (e.g., GPT-4o, Claude, Gemini) or remove the image.`,
-            },
-            { status: 400 },
-        )
-    }
+    // Note: we used to pre-emptively reject images for models we guessed were
+    // text-only (by name matching). That heuristic misfired on newer models
+    // (see issue #874), so we now let the request through and surface the real
+    // provider error if the model genuinely can't accept images.
 
     // User input only - XML is now in a separate cached system message
     const formattedUserInput = `User input:

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1420,76 +1420,13 @@ export function supportsPromptCaching(modelId: string): boolean {
 }
 
 /**
- * Check if a model supports image/vision input.
- * Some models silently drop image parts without error (AI SDK warning only).
- */
-export function supportsImageInput(modelId: string): boolean {
-    const lowerModelId = modelId.toLowerCase()
-
-    // Helper to check if model has vision capability indicator
-    const hasVisionIndicator =
-        lowerModelId.includes("vision") || lowerModelId.includes("vl")
-
-    // Models that DON'T support image/vision input (unless vision variant)
-    // Kimi K2 doesn't support images, but K2.5 does
-    // Only block kimi-k2 specifically, not other Kimi models
-    if (
-        (lowerModelId.includes("kimi-k2") ||
-            lowerModelId.includes("kimi_k2")) &&
-        !hasVisionIndicator &&
-        !lowerModelId.includes("2.5") &&
-        !lowerModelId.includes("k2.5")
-    ) {
-        return false
-    }
-
-    // Moonshot text models (moonshot-v1 series are text-only)
-    if (lowerModelId.includes("moonshot-v1") && !hasVisionIndicator) {
-        return false
-    }
-
-    // MiniMax text models (MiniMax-M2.x series are text-only; M3 supports image input)
-    if (
-        lowerModelId.includes("minimax") &&
-        !hasVisionIndicator &&
-        !lowerModelId.includes("m3")
-    ) {
-        return false
-    }
-
-    // DeepSeek text models (not vision variants)
-    if (lowerModelId.includes("deepseek") && !hasVisionIndicator) {
-        return false
-    }
-
-    // Qwen text models (not vision variants like qwen-vl)
-    // Qwen3.5 series (qwen3.5, qwen3.5-plus, qwen3.5-flash) natively support image input
-    // QvQ (Qwen Visual QA) models are vision models — exclude them even when prefixed with "qwen/"
-    if (
-        lowerModelId.includes("qwen") &&
-        !hasVisionIndicator &&
-        !lowerModelId.includes("qwen3.5") &&
-        !lowerModelId.includes("qvq")
-    ) {
-        return false
-    }
-
-    // GLM text models (not vision variants)
-    // GLM vision models: glm-4v, glm-4v-9b, glm-4.1v-9b-thinking
-    if (lowerModelId.includes("glm") && !hasVisionIndicator) {
-        if (!/[\d.]v/.test(lowerModelId)) {
-            return false
-        }
-    }
-
-    // Default: assume model supports images
-    return true
-}
-
-/**
  * Get the AI model for diagram validation.
  * Uses VALIDATION_MODEL env var if set, otherwise falls back to AI_MODEL.
- * Throws if the model doesn't support image input.
+ *
+ * Note: we no longer guess whether the model supports image input from its
+ * name — that heuristic misfired on newer models (see issue #874). If a
+ * configured validation model can't handle images, the API call simply errors
+ * and the validate-diagram route falls back to "valid".
  */
 export function getValidationModel(): ReturnType<typeof getAIModel>["model"] {
     // AI_MODEL may be comma-separated (multi-model fallback); pick the first.
@@ -1499,12 +1436,6 @@ export function getValidationModel(): ReturnType<typeof getAIModel>["model"] {
     if (!modelId) {
         throw new Error(
             "No validation model configured. Set VALIDATION_MODEL or AI_MODEL.",
-        )
-    }
-
-    if (!supportsImageInput(modelId)) {
-        throw new Error(
-            `Validation requires a vision-capable model. Model "${modelId}" does not support image input.`,
         )
     }
 

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -3,7 +3,6 @@ import {
     getAIModel,
     isAihubmixStandardBaseURL,
     resolveBaseURL,
-    supportsImageInput,
     supportsPromptCaching,
 } from "@/lib/ai-providers"
 import { extractAihubmixModelIds } from "@/lib/aihubmix-models"
@@ -180,89 +179,6 @@ describe("supportsPromptCaching", () => {
         expect(supportsPromptCaching("gpt-4o")).toBe(false)
         expect(supportsPromptCaching("gemini-pro")).toBe(false)
         expect(supportsPromptCaching("deepseek-chat")).toBe(false)
-    })
-})
-
-describe("supportsImageInput", () => {
-    it("returns true for models with vision capability", () => {
-        expect(supportsImageInput("gpt-4-vision")).toBe(true)
-        expect(supportsImageInput("qwen-vl")).toBe(true)
-        expect(supportsImageInput("deepseek-vl")).toBe(true)
-    })
-
-    it("returns false for Kimi K2 models without vision", () => {
-        expect(supportsImageInput("kimi-k2")).toBe(false)
-        expect(supportsImageInput("moonshot/kimi-k2")).toBe(false)
-    })
-
-    it("returns true for Kimi K2.5 models (supports vision)", () => {
-        expect(supportsImageInput("kimi-k2.5")).toBe(true)
-        expect(supportsImageInput("moonshotai/kimi-k2.5")).toBe(true)
-    })
-
-    it("returns false for Moonshot v1 text models", () => {
-        expect(supportsImageInput("moonshot-v1-8k")).toBe(false)
-        expect(supportsImageInput("moonshot-v1-32k")).toBe(false)
-        expect(supportsImageInput("moonshot-v1-128k")).toBe(false)
-    })
-
-    it("returns false for MiniMax M2 text models", () => {
-        expect(supportsImageInput("MiniMax-M2.7")).toBe(false)
-        expect(supportsImageInput("MiniMax-M2.7-highspeed")).toBe(false)
-        expect(supportsImageInput("MiniMax-M2")).toBe(false)
-    })
-
-    it("returns true for MiniMax M3 (supports image input)", () => {
-        expect(supportsImageInput("MiniMax-M3")).toBe(true)
-    })
-
-    it("returns false for DeepSeek text models", () => {
-        expect(supportsImageInput("deepseek-chat")).toBe(false)
-        expect(supportsImageInput("deepseek-coder")).toBe(false)
-    })
-
-    it("returns false for Qwen text models", () => {
-        expect(supportsImageInput("qwen-turbo")).toBe(false)
-        expect(supportsImageInput("qwen-plus")).toBe(false)
-        expect(supportsImageInput("qwen3-max")).toBe(false)
-    })
-
-    it("returns true for Qwen vision models", () => {
-        expect(supportsImageInput("qwen-vl")).toBe(true)
-        expect(supportsImageInput("Qwen3.5")).toBe(true)
-        expect(supportsImageInput("qwen3.5")).toBe(true)
-        expect(supportsImageInput("qwen3.5-plus")).toBe(true)
-        expect(supportsImageInput("qwen3.5-flash")).toBe(true)
-        expect(supportsImageInput("qwen3-vl-plus")).toBe(true)
-        expect(supportsImageInput("qwen3-vl-flash")).toBe(true)
-    })
-
-    it("returns true for QvQ (Qwen Visual QA) models including OpenRouter-prefixed names", () => {
-        expect(supportsImageInput("qvq-72b-preview")).toBe(true)
-        expect(supportsImageInput("qvq-max")).toBe(true)
-        expect(supportsImageInput("qwen/qvq-72b-preview")).toBe(true)
-        expect(supportsImageInput("qwen/qvq-max")).toBe(true)
-    })
-
-    it("returns false for GLM text models", () => {
-        expect(supportsImageInput("glm-4")).toBe(false)
-        expect(supportsImageInput("glm-4-plus")).toBe(false)
-        expect(supportsImageInput("glm-4-flash")).toBe(false)
-        expect(supportsImageInput("glm-4-long")).toBe(false)
-        expect(supportsImageInput("glm-4.7")).toBe(false)
-        expect(supportsImageInput("glm-5")).toBe(false)
-    })
-
-    it("returns true for GLM vision models", () => {
-        expect(supportsImageInput("glm-4v")).toBe(true)
-        expect(supportsImageInput("glm-4v-9b")).toBe(true)
-        expect(supportsImageInput("glm-4.1v-9b-thinking")).toBe(true)
-    })
-
-    it("returns true for Claude and GPT models by default", () => {
-        expect(supportsImageInput("claude-sonnet-4-5")).toBe(true)
-        expect(supportsImageInput("gpt-4o")).toBe(true)
-        expect(supportsImageInput("gemini-pro")).toBe(true)
     })
 })
 


### PR DESCRIPTION
## Background

Issue #874 reports that the multimodal (image input) gate relies on keyword-matching the model id string, which is "ugly" and fragile. It misfires on newer models such as `kimi-k3.6`, `k3.7`, and `qwen36` — `qwen36` was wrongly blocked because it contains `qwen`, while `kimi-k3.x` fell through to the default and was allowed.

## Why remove it instead of adding a toggle

The original purpose of `supportsImageInput()` was to pre-empt the case where an image gets dropped. After checking the installed AI SDK (`ai` 6.x + `@ai-sdk/openai-compatible` etc.), the SDK itself does **not** emit a warning or error when it sends an image to an endpoint: it just converts the image to `image_url` and forwards it. Whatever happens next is entirely up to the downstream API. So the name-based guess was the *only* pre-flight signal, and an unreliable one.

## Trade-off (honest)

Removing the guess is **not loss-free**. What the user sees now depends on how the downstream API handles an image sent to a text-only model:

| Downstream API behavior | User experience |
|---|---|
| Rejects with an error (most mainstream OpenAI-compatible APIs, e.g. DeepSeek / Qwen dashscope) | Clear error. If the message contains `image_url` / `image content block`, `chat-panel.tsx` translates it to "This model doesn't support image input." Otherwise the raw provider error is shown. |
| Silently ignores the image and answers from text only (some endpoints) | **No error at all** — the model confabulates as if it never saw the image. This is the regression cost. |

In exchange, capable models that were previously *wrongly blocked* (e.g. `qwen36`, `kimi-k3.6`) now work. Given the keyword heuristic was already producing false negatives on real models, trading a fragile guess for the real provider error (in the common case) is the simpler and more correct default.

Diagram validation degrades gracefully regardless — `validate-diagram` falls back to "valid" on any model error.

## Changes

- Remove `supportsImageInput()` and the pre-send 400 check in the chat route.
- Drop the vision-capability throw in `getValidationModel()`.
- Remove the corresponding unit tests.

3 files changed, 9 insertions(+), 169 deletions(-). Typecheck, lint, and unit tests pass.
