### PR TITLE
fix: remove user-scalable restriction, clean up unused dep and memory leak

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -25,8 +25,6 @@ const jetbrainsMono = JetBrains_Mono({
 export const viewport: Viewport = {
     width: "device-width",
     initialScale: 1,
-    maximumScale: 1,
-    userScalable: false,
 }
 
 // Generate static params for all locales

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # AI Provider Configuration
 # AI_PROVIDER: Which provider to use
-# Options: bedrock, openai, anthropic, google, vertexai, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, gateway, novita
+# Options: bedrock, openai, anthropic, google, vertexai, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, sglang, gateway, edgeone, doubao, modelscope, glm, qwen, qiniu, kimi, minimax, novita
 # Default: bedrock
 AI_PROVIDER=bedrock
 

--- a/hooks/use-diagram-tool-handlers.ts
+++ b/hooks/use-diagram-tool-handlers.ts
@@ -352,6 +352,7 @@ ${finalXml}
                                 : "Validation failed",
                         imageData: capturedPngData || undefined,
                     })
+                    validationRetryCountRef.current.delete(toolCall.toolCallId)
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@xmldom/xmldom": "^0.9.8",
         "ai": "^6.0.1",
-        "base-64": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",


### PR DESCRIPTION
Found a few things worth cleaning up:

- the viewport config had `userScalable: false` which prevents zooming — that's a WCAG accessibility violation and makes things harder for anyone who needs to zoom in on mobile
- `base-64` was listed as a dependency but never imported anywhere — the code uses native `atob`/`btoa` instead
- `env.example` was missing about 9 supported providers from the options comment (edgeone, doubao, modelscope, glm, qwen, qiniu, kimi, minimax, sglang)
- there was a small memory leak in the validation retry tracking — if VLM validation threw an error, the retry count for that tool call ID was never cleaned up from the map