### PR TITLE
ci: auto-publish mcp-server to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,67 @@
+name: Publish MCP Server
+
+# Publishes @next-ai-drawio/mcp-server to npm via OIDC trusted publishing
+# (no token, no OTP). Triggers when packages/mcp-server changes on main;
+# skips silently if the package.json version is already on npm — so a
+# release is just "bump the version in a PR and merge".
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/mcp-server/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # OIDC token for npm trusted publishing
+
+concurrency:
+  group: publish-mcp
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+          cache-dependency-path: packages/mcp-server/package-lock.json
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing requires npm >= 11.5.1
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Check if version is already published
+        id: version
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          if npm view "@next-ai-drawio/mcp-server@${LOCAL}" version >/dev/null 2>&1; then
+            echo "Version ${LOCAL} already on npm - nothing to publish"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version ${LOCAL} not on npm - publishing"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.publish == 'true'
+        run: npm ci
+
+      - name: Test
+        if: steps.version.outputs.publish == 'true'
+        run: npm test
+
+      - name: Publish to npm
+        if: steps.version.outputs.publish == 'true'
+        run: npm publish


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that publishes `@next-ai-drawio/mcp-server` to npm automatically, so releases no longer require a manual `npm publish` + 2FA OTP on a maintainer's machine.

## How it works

- Triggers on push to `main` when anything under `packages/mcp-server/` changes (plus manual `workflow_dispatch`)
- Compares `package.json` version against the npm registry; if that version is already published, the job exits quietly — so ordinary code merges don't attempt a publish
- When the version is new: `npm ci` → `npm test` → `npm publish`
- Auth is npm **trusted publishing (OIDC)**: the job's GitHub identity is exchanged for a short-lived npm credential. No `NPM_TOKEN` secret to store or rotate, no OTP, and it works with the strictest "require 2FA and disallow tokens" package setting

## Release flow after this merges

1. Bump the version in `packages/mcp-server/package.json` (in whatever PR ships the change)
2. Merge to `main` — the workflow publishes that version

## Setup required (one-time, on npmjs.com)

On the package's Settings page → **Trusted Publisher** → select **GitHub Actions** and enter:
- Organization or user: `DayuanJiang`
- Repository: `next-ai-draw-io`
- Workflow filename: `publish-mcp.yml`
- Environment: (leave empty)

Until that's configured, the publish step will fail with an auth error — everything else in the workflow still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)