### PR TITLE
fix: validate admin settings path before reporting writable

### DIFF
--- a/lib/admin/settings.ts
+++ b/lib/admin/settings.ts
@@ -110,7 +110,12 @@ let writableCache: boolean | null = null
 export function isSettingsWritable(): boolean {
     if (writableCache !== null) return writableCache
     try {
-        const dir = path.dirname(getSettingsPath())
+        const filePath = getSettingsPath()
+        if (fs.existsSync(filePath) && !fs.statSync(filePath).isFile()) {
+            writableCache = false
+            return writableCache
+        }
+        const dir = path.dirname(filePath)
         fs.mkdirSync(dir, { recursive: true })
         fs.accessSync(dir, fs.constants.W_OK)
         writableCache = true

--- a/tests/unit/admin-settings.test.ts
+++ b/tests/unit/admin-settings.test.ts
@@ -136,9 +136,9 @@ describe("isSettingsWritable", () => {
         expect(isSettingsWritable()).toBe(true)
     })
 
-    it("returns false for an unwritable path", () => {
+    it("returns false when the settings path is a directory", () => {
         _resetForTests()
-        process.env.SETTINGS_FILE = "/nonexistent-root-dir/settings.json"
+        process.env.SETTINGS_FILE = tmpDir
         expect(isSettingsWritable()).toBe(false)
     })
 })
@@ -152,7 +152,9 @@ describe("settings file on disk", () => {
             version: 1,
             values: { TEST_ADMIN_VAR: "secret" },
         })
-        const mode = fs.statSync(filePath).mode & 0o777
-        expect(mode).toBe(0o600)
+        if (process.platform !== "win32") {
+            const mode = fs.statSync(filePath).mode & 0o777
+            expect(mode).toBe(0o600)
+        }
     })
 })


### PR DESCRIPTION
## Summary

- reject `SETTINGS_FILE` when it points to an existing non-file target
- keep parent-directory writability checks for new settings files
- replace the POSIX/root-permission-dependent test fixture with a cross-platform regression case
- keep the `0600` mode assertion on POSIX while still verifying persisted JSON on Windows

## Why

`isSettingsWritable()` only checked the target's parent directory. A configured settings path that was itself a directory was therefore reported as writable even though `saveSettings()` could not write the temporary file and rename it into place.

The existing negative test also used `/nonexistent-root-dir/settings.json`, which is not reliably unwritable on Windows, while POSIX mode bits are not meaningful in the same way on Windows. Together these assumptions caused two unit-test failures on a supported Electron development platform.

## Testing

- `npm run test -- --run` — 153 tests passed
- `npx tsc --noEmit`
- `npm run build`
- `npx biome check lib/admin/settings.ts tests/unit/admin-settings.test.ts`
