### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/app/[lang]/about/page.tsx
+++ b/app/[lang]/about/page.tsx
@@ -340,6 +340,7 @@ export default function About() {
                         <li>Azure OpenAI</li>
                         <li>Ollama</li>
                         <li>OpenRouter</li>
+                        <li>Requesty</li>
                         <li>DeepSeek</li>
                         <li>SiliconFlow</li>
                         <li>ModelScope</li>

--- a/app/api/validate-model/route.ts
+++ b/app/api/validate-model/route.ts
@@ -158,6 +158,18 @@ export async function POST(req: Request) {
                 break
             }
 
+            case "requesty": {
+                const requesty = createOpenAI({
+                    apiKey,
+                    baseURL:
+                        baseUrl ||
+                        PROVIDER_INFO.requesty.defaultBaseUrl ||
+                        "https://router.requesty.ai/v1",
+                })
+                model = requesty.chat(modelId)
+                break
+            }
+
             case "aihubmix": {
                 const defaultBaseURL = PROVIDER_INFO.aihubmix.defaultBaseUrl
 

--- a/docs/en/ai-providers.md
+++ b/docs/en/ai-providers.md
@@ -182,6 +182,22 @@ Optional custom endpoint:
 OPENROUTER_BASE_URL=https://your-custom-endpoint
 ```
 
+### Requesty
+
+```bash
+AI_PROVIDER=requesty
+REQUESTY_API_KEY=your_api_key
+AI_MODEL=openai/gpt-4o-mini
+```
+
+Optional custom endpoint:
+
+```bash
+REQUESTY_BASE_URL=https://router.requesty.ai/v1
+```
+
+Requesty is an OpenAI-compatible router and uses `provider/model` model IDs (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`). See https://docs.requesty.ai and https://app.requesty.ai/router/list for the full model list.
+
 ### Ollama (Local)
 
 ```bash
@@ -343,7 +359,7 @@ If you only configure **one** provider's API key, the system will automatically 
 If you configure **multiple** API keys, you must explicitly set `AI_PROVIDER`:
 
 ```bash
-AI_PROVIDER=google  # or: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, qwen, kimi, qiniu, mimo
+AI_PROVIDER=google  # or: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, requesty, ollama, gateway, sglang, modelscope, minimax, glm, qwen, kimi, qiniu, mimo
 ```
 
 ## Server-Side Multi-Model Configuration

--- a/electron/main/config-manager.ts
+++ b/electron/main/config-manager.ts
@@ -349,6 +349,10 @@ const PROVIDER_ENV_MAP: Record<string, { apiKey: string; baseUrl: string }> = {
         apiKey: "OPENROUTER_API_KEY",
         baseUrl: "OPENROUTER_BASE_URL",
     },
+    requesty: {
+        apiKey: "REQUESTY_API_KEY",
+        baseUrl: "REQUESTY_BASE_URL",
+    },
     deepseek: { apiKey: "DEEPSEEK_API_KEY", baseUrl: "DEEPSEEK_BASE_URL" },
     siliconflow: {
         apiKey: "SILICONFLOW_API_KEY",

--- a/electron/settings/index.html
+++ b/electron/settings/index.html
@@ -53,6 +53,7 @@
                             <option value="azure">Azure OpenAI</option>
                             <option value="bedrock">AWS Bedrock</option>
                             <option value="openrouter">OpenRouter</option>
+                            <option value="requesty">Requesty</option>
                             <option value="deepseek">DeepSeek</option>
                             <option value="siliconflow">SiliconFlow</option>
                             <option value="modelscope">ModelScope</option>

--- a/electron/settings/settings.js
+++ b/electron/settings/settings.js
@@ -286,6 +286,7 @@ function getProviderLabel(provider) {
         azure: "Azure OpenAI",
         bedrock: "AWS Bedrock",
         openrouter: "OpenRouter",
+        requesty: "Requesty",
         deepseek: "DeepSeek",
         siliconflow: "SiliconFlow",
         modelscope: "ModelScope",

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # AI Provider Configuration
 # AI_PROVIDER: Which provider to use
-# Options: bedrock, openai, anthropic, google, vertexai, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, gateway, novita
+# Options: bedrock, openai, anthropic, google, vertexai, azure, ollama, openrouter, requesty, aihubmix, deepseek, siliconflow, gateway, novita
 # Default: bedrock
 AI_PROVIDER=bedrock
 
@@ -72,6 +72,12 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 # OpenRouter Configuration
 # OPENROUTER_API_KEY=sk-or-v1-...
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1  # Optional: Custom endpoint
+
+# Requesty Configuration (OpenAI-compatible)
+# Model format: "provider/model" e.g., "openai/gpt-4o-mini", "anthropic/claude-sonnet-4-5"
+# Get your API key from: https://app.requesty.ai/api-keys
+# REQUESTY_API_KEY=your-requesty-api-key
+# REQUESTY_BASE_URL=https://router.requesty.ai/v1  # Optional: Custom endpoint (EU: https://router.eu.requesty.ai/v1)
 
 # AIHubMix Configuration
 # AIHUBMIX_API_KEY=your-aihubmix-api-key

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -102,6 +102,7 @@ const ALLOWED_CLIENT_PROVIDERS: ProviderName[] = [
     "azure",
     "bedrock",
     "openrouter",
+    "requesty",
     "aihubmix",
     "deepseek",
     "siliconflow",
@@ -531,6 +532,7 @@ function buildProviderOptions(
 
         case "deepseek":
         case "openrouter":
+        case "requesty":
         case "aihubmix":
         case "siliconflow":
         case "sglang":
@@ -566,6 +568,7 @@ export const PROVIDER_ENV_VARS: Record<ProviderName, string | null> = {
     azure: "AZURE_API_KEY",
     ollama: null, // No credentials needed for local Ollama
     openrouter: "OPENROUTER_API_KEY",
+    requesty: "REQUESTY_API_KEY",
     aihubmix: "AIHUBMIX_API_KEY",
     deepseek: "DEEPSEEK_API_KEY",
     siliconflow: "SILICONFLOW_API_KEY",
@@ -684,7 +687,7 @@ function validateProviderCredentials(
  * Get the AI model based on environment variables
  *
  * Environment variables:
- * - AI_PROVIDER: The provider to use (bedrock, openai, anthropic, google, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, sglang, gateway, modelscope)
+ * - AI_PROVIDER: The provider to use (bedrock, openai, anthropic, google, azure, ollama, openrouter, requesty, aihubmix, deepseek, siliconflow, sglang, gateway, modelscope)
  * - AI_MODEL: The model ID/name for the selected provider
  *
  * Provider-specific env vars:
@@ -696,6 +699,7 @@ function validateProviderCredentials(
  * - AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY: AWS Bedrock credentials
  * - OLLAMA_BASE_URL: Ollama server URL (optional, defaults to https://ollama.com/api)
  * - OPENROUTER_API_KEY: OpenRouter API key
+ * - REQUESTY_API_KEY: Requesty API key
  * - AIHUBMIX_API_KEY: AIHubMix API key
  * - DEEPSEEK_API_KEY: DeepSeek API key
  * - DEEPSEEK_BASE_URL: DeepSeek endpoint (optional)
@@ -786,6 +790,7 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
                         `- GOOGLE_GENERATIVE_AI_API_KEY for Google\n` +
                         `- AWS_ACCESS_KEY_ID for Bedrock\n` +
                         `- OPENROUTER_API_KEY for OpenRouter\n` +
+                        `- REQUESTY_API_KEY for Requesty\n` +
                         `- AIHUBMIX_API_KEY for AIHubMix\n` +
                         `- AZURE_API_KEY for Azure\n` +
                         `- SILICONFLOW_API_KEY for SiliconFlow\n` +
@@ -1026,6 +1031,26 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
                 ...(baseURL && { baseURL }),
             })
             model = openrouter(modelId)
+            break
+        }
+
+        case "requesty": {
+            const apiKey = resolveApiKey(overrides, "REQUESTY_API_KEY")
+            const serverBaseUrl = resolveBaseUrlEnv(
+                overrides,
+                "REQUESTY_BASE_URL",
+            )
+            const baseURL = resolveBaseURL(
+                overrides?.apiKey,
+                overrides?.baseUrl,
+                serverBaseUrl,
+                PROVIDER_INFO.requesty.defaultBaseUrl,
+            )
+            const requesty = createOpenAI({
+                apiKey,
+                ...(baseURL && { baseURL }),
+            })
+            model = requesty.chat(modelId)
             break
         }
 
@@ -1414,7 +1439,7 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
 
         default:
             throw new Error(
-                `Unknown AI provider: ${provider}. Supported providers: bedrock, openai, anthropic, google, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, sglang, gateway, edgeone, doubao, modelscope, glm, qwen, qiniu, kimi, minimax, novita, mimo`,
+                `Unknown AI provider: ${provider}. Supported providers: bedrock, openai, anthropic, google, azure, ollama, openrouter, requesty, aihubmix, deepseek, siliconflow, sglang, gateway, edgeone, doubao, modelscope, glm, qwen, qiniu, kimi, minimax, novita, mimo`,
             )
     }
 

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -27,6 +27,7 @@
         "google": "Google",
         "azure": "Azure OpenAI",
         "openrouter": "OpenRouter",
+        "requesty": "Requesty",
         "deepseek": "DeepSeek",
         "siliconflow": "SiliconFlow",
         "modelscope": "ModelScope",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -27,6 +27,7 @@
         "google": "Google",
         "azure": "Azure OpenAI",
         "openrouter": "OpenRouter",
+        "requesty": "Requesty",
         "deepseek": "DeepSeek",
         "siliconflow": "SiliconFlow",
         "modelscope": "ModelScope",

--- a/lib/i18n/dictionaries/zh-Hant.json
+++ b/lib/i18n/dictionaries/zh-Hant.json
@@ -27,6 +27,7 @@
         "google": "Google",
         "azure": "Azure OpenAI",
         "openrouter": "OpenRouter",
+        "requesty": "Requesty",
         "deepseek": "DeepSeek",
         "siliconflow": "SiliconFlow",
         "modelscope": "ModelScope",

--- a/lib/i18n/dictionaries/zh.json
+++ b/lib/i18n/dictionaries/zh.json
@@ -27,6 +27,7 @@
         "google": "Google",
         "azure": "Azure OpenAI",
         "openrouter": "OpenRouter",
+        "requesty": "Requesty",
         "deepseek": "DeepSeek",
         "siliconflow": "SiliconFlow",
         "modelscope": "ModelScope",

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -9,6 +9,7 @@ export type ProviderName =
     | "bedrock"
     | "ollama"
     | "openrouter"
+    | "requesty"
     | "aihubmix"
     | "deepseek"
     | "siliconflow"
@@ -104,6 +105,7 @@ export const PROVIDER_LOGO_MAP: Record<string, string> = {
     azure: "azure",
     bedrock: "amazon-bedrock",
     openrouter: "openrouter",
+    requesty: "requesty",
     aihubmix: "aihubmix",
     deepseek: "deepseek",
     siliconflow: "siliconflow",
@@ -148,6 +150,10 @@ export const PROVIDER_INFO: Record<
     openrouter: {
         label: "OpenRouter",
         defaultBaseUrl: "https://openrouter.ai/api/v1",
+    },
+    requesty: {
+        label: "Requesty",
+        defaultBaseUrl: "https://router.requesty.ai/v1",
     },
     aihubmix: {
         label: "AIHubMix",
@@ -328,6 +334,12 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
         "qwen/qwen3-coder",
         // MiniMax
         "minimax/minimax-m3",
+    ],
+    requesty: [
+        // OpenAI
+        "openai/gpt-4o-mini",
+        // Anthropic
+        "anthropic/claude-sonnet-4-5",
     ],
     aihubmix: [
         // Fallback list. The settings UI loads the live model list from AIHubMix when available.


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible provider

This adds [Requesty](https://requesty.ai) as an AI provider by mirroring the existing OpenRouter integration.

Requesty is an OpenAI-compatible LLM router that exposes 400+ models behind a single endpoint using `provider/model` naming (the same convention as OpenRouter), so it fits the existing provider architecture directly.

### Changes
- `lib/types/model-config.ts`: add `requesty` to the `ProviderName` union, `PROVIDER_LOGO_MAP`, `PROVIDER_INFO` (label + base URL `https://router.requesty.ai/v1`), and `SUGGESTED_MODELS` (`openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).
- `lib/ai-providers.ts`: add `requesty` to the allowed providers, the env-var map (`REQUESTY_API_KEY`), and a model-factory case using `createOpenAI` (base URL overridable via `REQUESTY_BASE_URL`).
- `app/api/validate-model/route.ts`: `requesty` validation case.
- `electron/settings/index.html`, `electron/settings/settings.js`, `electron/main/config-manager.ts`: provider option, label, and env map in the desktop settings.
- `env.example`: Requesty configuration block.
- `docs/en/ai-providers.md`, `app/[lang]/about/page.tsx`, and all i18n dictionaries (`en`, `zh`, `ja`, `zh-Hant`), provider listing.

### Testing
- `tsc --noEmit`: clean.
- Verified live against the Requesty endpoint (same base URL + Bearer auth the provider uses): a call to `openai/gpt-4o-mini` returned the expected completion with HTTP 200.

Config: get a key at https://app.requesty.ai/api-keys, model list at https://app.requesty.ai/router/list, docs at https://docs.requesty.ai.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

