### PR TITLE
feat:add thinking option

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -216,6 +216,12 @@ async function handleChatRequest(req: Request): Promise<Response> {
         baseUrl,
         apiKey: req.headers.get("x-ai-api-key"),
         modelId: req.headers.get("x-ai-model"),
+        thinkingEnabled:
+            req.headers.get("x-ai-thinking-enabled") === "true"
+                ? true
+                : req.headers.get("x-ai-thinking-enabled") === "false"
+                  ? false
+                  : undefined,
         // AWS Bedrock credentials
         awsAccessKeyId: req.headers.get("x-aws-access-key-id"),
         awsSecretAccessKey: req.headers.get("x-aws-secret-access-key"),

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1082,6 +1082,11 @@ export default function ChatPanel({
                             "x-ai-api-key": config.aiApiKey,
                         }),
                         ...(config.aiModel && { "x-ai-model": config.aiModel }),
+                        ...(config.thinkingEnabled !== undefined && {
+                            "x-ai-thinking-enabled": String(
+                                config.thinkingEnabled,
+                            ),
+                        }),
                         // AWS Bedrock credentials
                         ...(config.awsAccessKeyId && {
                             "x-aws-access-key-id": config.awsAccessKeyId,

--- a/components/model-config-dialog.tsx
+++ b/components/model-config-dialog.tsx
@@ -56,6 +56,7 @@ import { useDictionary } from "@/hooks/use-dictionary"
 import type { UseModelConfigReturn } from "@/hooks/use-model-config"
 import { getApiEndpoint } from "@/lib/base-path"
 import { formatMessage } from "@/lib/i18n/utils"
+import { supportsThinkingToggle } from "@/lib/thinking-capabilities"
 import type { ProviderConfig, ProviderName } from "@/lib/types/model-config"
 import { PROVIDER_INFO, SUGGESTED_MODELS } from "@/lib/types/model-config"
 import { cn } from "@/lib/utils"
@@ -1138,6 +1139,52 @@ export function ModelConfigDialog({
                                                                         }}
                                                                         className="flex-1 min-w-0 font-mono text-sm h-8 border-0 bg-transparent focus-visible:bg-background focus-visible:ring-1"
                                                                     />
+                                                                    {supportsThinkingToggle(
+                                                                        selectedProvider.provider,
+                                                                        model.modelId,
+                                                                    ) && (
+                                                                        <div className="flex shrink-0 items-center gap-1.5">
+                                                                            <Label
+                                                                                htmlFor={`thinking-${model.id}`}
+                                                                                className="cursor-pointer text-[11px] text-muted-foreground"
+                                                                            >
+                                                                                {
+                                                                                    dict
+                                                                                        .modelConfig
+                                                                                        .thinkingMode
+                                                                                }
+                                                                            </Label>
+                                                                            <Switch
+                                                                                id={`thinking-${model.id}`}
+                                                                                checked={
+                                                                                    model.thinkingEnabled ??
+                                                                                    true
+                                                                                }
+                                                                                onCheckedChange={(
+                                                                                    thinkingEnabled,
+                                                                                ) => {
+                                                                                    if (
+                                                                                        selectedProviderId &&
+                                                                                        model.thinkingEnabled !==
+                                                                                            thinkingEnabled
+                                                                                    ) {
+                                                                                        updateModel(
+                                                                                            selectedProviderId,
+                                                                                            model.id,
+                                                                                            {
+                                                                                                thinkingEnabled,
+                                                                                            },
+                                                                                        )
+                                                                                    }
+                                                                                }}
+                                                                                aria-label={
+                                                                                    dict
+                                                                                        .modelConfig
+                                                                                        .thinkingMode
+                                                                                }
+                                                                            />
+                                                                        </div>
+                                                                    )}
                                                                     <Button
                                                                         variant="ghost"
                                                                         size="icon"

--- a/hooks/use-model-config.ts
+++ b/hooks/use-model-config.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import { getApiEndpoint } from "@/lib/base-path"
 import type { FlattenedServerModel } from "@/lib/server-model-config"
 import { STORAGE_KEYS } from "@/lib/storage"
+import { supportsThinkingToggle } from "@/lib/thinking-capabilities"
 import {
     createEmptyConfig,
     createModelConfig,
@@ -121,7 +122,7 @@ export interface UseModelConfigReturn {
         updates: Partial<ProviderConfig>,
     ) => void
     deleteProvider: (providerId: string) => void
-    addModel: (providerId: string, modelId: string) => ModelConfig
+    addModel: (providerId: string, modelId: string) => void
     updateModel: (
         providerId: string,
         modelConfigId: string,
@@ -279,21 +280,29 @@ export function useModelConfig(): UseModelConfigReturn {
         })
     }, [])
 
-    const addModel = useCallback(
-        (providerId: string, modelId: string): ModelConfig => {
+    const addModel = useCallback((providerId: string, modelId: string) => {
+        setConfig((prev) => {
+            const provider = prev.providers.find((p) => p.id === providerId)
             const newModel = createModelConfig(modelId)
-            setConfig((prev) => ({
+            // Only new, known-capable models get an explicit default.
+            // Existing localStorage records stay undefined for compatibility.
+            if (
+                provider &&
+                supportsThinkingToggle(provider.provider, modelId)
+            ) {
+                newModel.thinkingEnabled = true
+            }
+
+            return {
                 ...prev,
                 providers: prev.providers.map((p) =>
                     p.id === providerId
                         ? { ...p, models: [...p.models, newModel] }
                         : p,
                 ),
-            }))
-            return newModel
-        },
-        [],
-    )
+            }
+        })
+    }, [])
 
     const updateModel = useCallback(
         (
@@ -386,6 +395,7 @@ export function getSelectedAIConfig(): {
     selectedModelId: string
     // Vertex AI credentials (Express Mode)
     vertexApiKey: string
+    thinkingEnabled?: boolean
 } {
     const empty = {
         accessCode: "",
@@ -399,6 +409,7 @@ export function getSelectedAIConfig(): {
         awsSessionToken: "",
         selectedModelId: "",
         vertexApiKey: "",
+        thinkingEnabled: undefined,
     }
 
     if (typeof window === "undefined") return empty
@@ -423,6 +434,7 @@ export function getSelectedAIConfig(): {
             awsSessionToken: "",
             selectedModelId: "",
             vertexApiKey: "",
+            thinkingEnabled: undefined,
         }
     }
 
@@ -478,5 +490,6 @@ export function getSelectedAIConfig(): {
         selectedModelId: config.selectedModelId || "",
         // Vertex AI credentials (Express Mode)
         vertexApiKey: model.vertexApiKey || "",
+        thinkingEnabled: model.thinkingEnabled,
     }
 }

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -10,6 +10,7 @@ import { aihubmix, createAihubmix } from "@aihubmix/ai-sdk-provider"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import { createOllama, ollama } from "ollama-ai-provider-v2"
+import { supportsThinkingToggle } from "@/lib/thinking-capabilities"
 import { PROVIDER_INFO, type ProviderName } from "@/lib/types/model-config"
 
 export type { ProviderName }
@@ -91,6 +92,7 @@ export interface ClientOverrides {
     // Can be a single string or array of strings for load balancing
     apiKeyEnv?: string | string[]
     baseUrlEnv?: string
+    thinkingEnabled?: boolean
 }
 
 // Providers that can be selected from client settings
@@ -259,6 +261,7 @@ function parseIntSafe(
 function buildProviderOptions(
     provider: ProviderName,
     modelId?: string,
+    thinkingEnabled?: boolean,
 ): Record<string, any> | undefined {
     const options: Record<string, any> = {}
 
@@ -306,6 +309,18 @@ function buildProviderOptions(
                         | "detailed"
                 }
             }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                options.openai = {
+                    ...options.openai,
+                    reasoningEffort: thinkingEnabled
+                        ? process.env.OPENAI_REASONING_EFFORT || "medium"
+                        : "none",
+                }
+            }
             break
         }
 
@@ -325,6 +340,24 @@ function buildProviderOptions(
                         type: thinkingType,
                         budgetTokens: thinkingBudget,
                     },
+                }
+            }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                // Anthropic turns manual extended thinking off by omitting
+                // `thinking`; `type: "disabled"` is not a Messages API mode.
+                if (thinkingEnabled) {
+                    options.anthropic = {
+                        thinking: {
+                            type: "enabled",
+                            budgetTokens: thinkingBudget || 1024,
+                        },
+                    }
+                } else {
+                    delete options.anthropic
                 }
             }
             break
@@ -412,6 +445,19 @@ function buildProviderOptions(
             if (Object.keys(options_obj).length > 0) {
                 options.google = { ...options.google, ...options_obj }
             }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                options.google = {
+                    ...options.google,
+                    thinkingConfig: {
+                        ...(options.google?.thinkingConfig || {}),
+                        thinkingBudget: thinkingEnabled ? -1 : 0,
+                    },
+                }
+            }
             break
         }
         case "vertexai": {
@@ -452,6 +498,19 @@ function buildProviderOptions(
                 }
                 options.google = { thinkingConfig }
             }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                options.google = {
+                    ...options.google,
+                    thinkingConfig: {
+                        ...(options.google?.thinkingConfig || {}),
+                        thinkingBudget: thinkingEnabled ? -1 : 0,
+                    },
+                }
+            }
             break
         }
         case "azure": {
@@ -471,6 +530,18 @@ function buildProviderOptions(
                         | "none"
                         | "brief"
                         | "detailed"
+                }
+            }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                options.azure = {
+                    ...options.azure,
+                    reasoningEffort: thinkingEnabled
+                        ? process.env.AZURE_REASONING_EFFORT || "medium"
+                        : "none",
                 }
             }
             break
@@ -518,6 +589,41 @@ function buildProviderOptions(
 
                 options.bedrock = { reasoningConfig }
             }
+            if (
+                modelId &&
+                thinkingEnabled !== undefined &&
+                supportsThinkingToggle(provider, modelId)
+            ) {
+                const isClaude =
+                    modelId.includes("claude") || modelId.includes("anthropic")
+                if (!thinkingEnabled && isClaude) {
+                    // Claude extended thinking is disabled by omitting the
+                    // `thinking` object; it has no `type: "disabled"` mode.
+                    delete options.bedrock
+                } else if (!thinkingEnabled) {
+                    // Nova 2 Lite exposes an explicit binary switch.
+                    options.bedrock = {
+                        ...options.bedrock,
+                        reasoningConfig: { type: "disabled" },
+                    }
+                } else {
+                    options.bedrock = {
+                        ...options.bedrock,
+                        reasoningConfig: {
+                            ...(options.bedrock?.reasoningConfig || {}),
+                            type: "enabled",
+                            ...(isClaude
+                                ? { budgetTokens: budgetTokens || 1024 }
+                                : {
+                                      maxReasoningEffort:
+                                          process.env
+                                              .BEDROCK_REASONING_EFFORT ||
+                                          "medium",
+                                  }),
+                        },
+                    }
+                }
+            }
             break
         }
 
@@ -530,7 +636,25 @@ function buildProviderOptions(
             break
         }
 
-        case "deepseek":
+        case "deepseek": {
+            // DeepSeek V4 models enable thinking by default. This application
+            // needs predictable, compact tool-call output because diagrams
+            // are returned as draw.io XML. Keep thinking disabled for all
+            // DeepSeek requests unless this is explicitly changed later.
+            options.deepseek = {
+                thinking: {
+                    type:
+                        thinkingEnabled !== undefined &&
+                        supportsThinkingToggle(provider, modelId || "")
+                            ? thinkingEnabled
+                                ? "enabled"
+                                : "disabled"
+                            : "disabled",
+                },
+            }
+            break
+        }
+
         case "openrouter":
         case "aihubmix":
         case "siliconflow":
@@ -817,7 +941,11 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
     let headers: Record<string, string> | undefined
 
     // Build provider-specific options from environment variables
-    const customProviderOptions = buildProviderOptions(provider, modelId)
+    const customProviderOptions = buildProviderOptions(
+        provider,
+        modelId,
+        overrides?.thinkingEnabled,
+    )
 
     switch (provider) {
         case "bedrock": {

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -406,7 +406,8 @@
         "unvalidatedModelWarning": "This model has not been validated",
         "serverDefaultModel": "Server default model",
         "showValue": "Show value",
-        "hideValue": "Hide value"
+        "hideValue": "Hide value",
+        "thinkingMode": "Thinking mode"
     },
     "admin": {
         "title": "Admin Settings",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -360,7 +360,8 @@
         "unvalidatedModelWarning": "このモデルは検証されていません",
         "serverDefaultModel": "サーバーデフォルトモデル",
         "showValue": "値を表示",
-        "hideValue": "値を非表示"
+        "hideValue": "値を非表示",
+        "thinkingMode": "思考モード"
     },
     "templates": {
         "title": "マイテンプレート",

--- a/lib/i18n/dictionaries/zh-Hant.json
+++ b/lib/i18n/dictionaries/zh-Hant.json
@@ -406,7 +406,8 @@
         "unvalidatedModelWarning": "此模型尚未驗證",
         "serverDefaultModel": "伺服器預設模型",
         "showValue": "顯示值",
-        "hideValue": "隱藏值"
+        "hideValue": "隱藏值",
+        "thinkingMode": "思考模式"
     },
     "admin": {
         "title": "管理員設定",

--- a/lib/i18n/dictionaries/zh.json
+++ b/lib/i18n/dictionaries/zh.json
@@ -406,7 +406,8 @@
         "unvalidatedModelWarning": "此模型尚未验证",
         "serverDefaultModel": "服务器默认模型",
         "showValue": "显示值",
-        "hideValue": "隐藏值"
+        "hideValue": "隐藏值",
+        "thinkingMode": "思考模式"
     },
     "admin": {
         "title": "管理员设置",

--- a/lib/thinking-capabilities.ts
+++ b/lib/thinking-capabilities.ts
@@ -1,0 +1,53 @@
+import { type ProviderName, SUGGESTED_MODELS } from "@/lib/types/model-config"
+
+/**
+ * Suggested models in this app that expose a native, binary thinking switch.
+ * Keep this explicit: custom IDs and aggregation endpoints must not gain a
+ * toggle merely because their name resembles a supported model.
+ */
+export function supportsThinkingToggle(
+    provider: ProviderName,
+    modelId: string,
+): boolean {
+    const id = modelId.toLowerCase()
+
+    // The setting is intentionally scoped to the curated list in
+    // `model-config.ts`. A manually entered model never inherits it just by
+    // sharing an ID pattern with a supported suggestion.
+    if (
+        !SUGGESTED_MODELS[provider]?.some((model) => model.toLowerCase() === id)
+    ) {
+        return false
+    }
+
+    switch (provider) {
+        case "openai":
+            return [
+                "gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
+            ].includes(id)
+        case "azure":
+            return ["gpt-5.5", "gpt-5.4", "gpt-5.1"].includes(id)
+        case "anthropic":
+            return [
+                "claude-sonnet-4-5-20250929",
+                "claude-opus-4-5-20251101",
+                "claude-3-7-sonnet-20250219",
+            ].includes(id)
+        case "google":
+        case "vertexai":
+            return ["gemini-2.5-flash", "gemini-2.5-flash-lite"].includes(id)
+        case "bedrock":
+            return [
+                "amazon.nova-2-lite-v1:0",
+                "anthropic.claude-opus-4-5-20251101-v1:0",
+                "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            ].includes(id)
+        case "deepseek":
+            return ["deepseek-v4-pro", "deepseek-v4-flash"].includes(id)
+        default:
+            return false
+    }
+}

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -32,6 +32,8 @@ export interface ModelConfig {
     modelId: string // e.g., "gpt-4o", "claude-sonnet-4-5"
     validated?: boolean // Has this model been validated
     validationError?: string // Error message if validation failed
+    // Explicit per-model override. Undefined preserves legacy/provider defaults.
+    thinkingEnabled?: boolean
 }
 
 // Provider configuration
@@ -82,6 +84,7 @@ export interface FlattenedModel {
     source?: "user" | "server"
     // Whether this model is the server default (matches AI_MODEL env var)
     isDefault?: boolean
+    thinkingEnabled?: boolean
     // Custom env var name(s) for server models
     // Can be a single string or array of strings for load balancing
     apiKeyEnv?: string | string[]
@@ -515,6 +518,7 @@ export function flattenModels(config: MultiModelConfig): FlattenedModel[] {
                 validated: model.validated,
                 source: "user",
                 isDefault: false,
+                thinkingEnabled: model.thinkingEnabled,
             })
         }
     }

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -7,6 +7,49 @@ import {
 } from "@/lib/ai-providers"
 import { extractAihubmixModelIds } from "@/lib/aihubmix-models"
 
+describe("per-model thinking overrides", () => {
+    it("overrides the legacy DeepSeek default only when explicitly set", () => {
+        expect(
+            getAIModel({
+                provider: "deepseek",
+                apiKey: "client-key",
+                modelId: "deepseek-v4-pro",
+                thinkingEnabled: true,
+            }).providerOptions,
+        ).toEqual({ deepseek: { thinking: { type: "enabled" } } })
+
+        expect(
+            getAIModel({
+                provider: "deepseek",
+                apiKey: "client-key",
+                modelId: "deepseek-v4-pro",
+                thinkingEnabled: false,
+            }).providerOptions,
+        ).toEqual({ deepseek: { thinking: { type: "disabled" } } })
+    })
+
+    it("omits Anthropic manual thinking when explicitly disabled", () => {
+        expect(
+            getAIModel({
+                provider: "anthropic",
+                apiKey: "client-key",
+                modelId: "claude-sonnet-4-5-20250929",
+                thinkingEnabled: false,
+            }).providerOptions,
+        ).toBeUndefined()
+    })
+
+    it("uses Nova 2 Lite's explicit disabled reasoningConfig", () => {
+        expect(
+            getAIModel({
+                provider: "bedrock",
+                modelId: "amazon.nova-2-lite-v1:0",
+                thinkingEnabled: false,
+            }).providerOptions,
+        ).toEqual({ bedrock: { reasoningConfig: { type: "disabled" } } })
+    })
+})
+
 describe("extractAihubmixModelIds", () => {
     it("extracts unique chat model IDs from the AIHubMix model list payload", () => {
         const models = extractAihubmixModelIds({


### PR DESCRIPTION
为模型配置新增“思考模式”开关。
- 仅在 SUGGESTED_MODELS 中、且官方 API 支持按请求启用/关闭思考的模型上显示。
- 开关状态随本地模型配置保存；新增支持模型默认开启，旧配置保持原有行为。
- 聊天请求会按不同厂商的官方参数传递设置：OpenAI/Azure 的 reasoningEffort、Gemini 的 thinkingBudget、Claude 的 thinking、Bedrock Nova 的 reasoningConfig、DeepSeek 的 thinking.type。
- 不支持真正关闭思考、聚合平台或手动输入的模型不显示开关。