### PR TITLE
ci: exclude public/ from Biome and disable automerge for Biome updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,11 @@
             "matchPackagePatterns": ["@ai-sdk/*", "ai", "next"],
             "groupName": "Core framework packages",
             "automerge": false
+        },
+        {
+            "matchPackageNames": ["@biomejs/biome"],
+            "groupName": "Biome",
+            "automerge": false
         }
     ],
     "vulnerabilityAlerts": {

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
     },
     "files": {
         "ignoreUnknown": false,
-        "includes": ["**", "!public/**/*.svg"]
+        "includes": ["**", "!public"]
     },
     "formatter": {
         "enabled": true,


### PR DESCRIPTION
## Summary
- Exclude the entire `public/` directory from Biome instead of just `public/**/*.svg`, so future Biome parser changes can never break CI on generated assets again.
- Disable Renovate automerge for `@biomejs/biome` so its updates require a manual look at CI before merging.

## Background
Renovate auto-merged the Biome 2.4.13 → 2.5.7 update (#904) even though the `ci` and `Lint & Unit Tests` checks were failing on that commit. Biome 2.5.7 started parsing SVG files, so lint blew up on `public/resnet50.svg` (a generated draw.io asset with embedded CSS animations). This also turned CI red on every open PR based on an older main, e.g. #895, until each one merged main.

This is the second time a Biome version change broke CI on unrelated PRs (the first was fixed by pinning the version in the auto-format workflow, #869). Lint tools change behavior in minor releases, so their updates shouldn't automerge.

## Verification
- `npx biome ci .` — 0 errors (41 pre-existing warnings, non-blocking)
- `npx vitest run` — 156/156 passed
- `npx tsc --noEmit` — clean
- Confirmed `public/resnet50.svg` is ignored by the new includes pattern
