### PR TITLE
fix: send an output token limit instead of relying on the provider's default

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -493,9 +493,9 @@ IMPORTANT: The "Current diagram XML" is the SINGLE SOURCE OF TRUTH for what's on
     const result = streamText({
         model,
         abortSignal: req.signal,
-        ...(process.env.MAX_OUTPUT_TOKENS && {
-            maxOutputTokens: parseInt(process.env.MAX_OUTPUT_TOKENS, 10),
-        }),
+        // Must be sent: unset means the provider's own default, and Bedrock's is 4096 —
+        // enough for a small diagram, so larger ones were cut off mid-attribute.
+        maxOutputTokens: Number(process.env.MAX_OUTPUT_TOKENS) || 16000,
         stopWhen: stepCountIs(5),
         // Repair truncated tool calls when maxOutputTokens is reached mid-JSON
         experimental_repairToolCall: async ({ toolCall, error }) => {

--- a/env.example
+++ b/env.example
@@ -11,6 +11,9 @@ AI_PROVIDER=bedrock
 # Example: AI_MODEL=doubao-seed-1-8-251215,doubao-seed-1-6-flash,doubao-seed-1-6-pro
 AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 
+# Output limit, all providers (default: 16000). Raise it if large diagrams arrive cut off.
+# MAX_OUTPUT_TOKENS=16000
+
 # AWS Bedrock Configuration
 # AWS_REGION=us-east-1
 # AWS_ACCESS_KEY_ID=your-access-key-id


### PR DESCRIPTION
## The problem

`maxOutputTokens` was only sent when `MAX_OUTPUT_TOKENS` happened to be set:

```ts
...(process.env.MAX_OUTPUT_TOKENS && {
    maxOutputTokens: parseInt(process.env.MAX_OUTPUT_TOKENS, 10),
}),
```

Leaving it unset does not give you the model's own maximum. The provider fills in its own,
and Bedrock's is **4096 output tokens**. Measured directly, no guesswork:

```
converse(modelId="us.anthropic.claude-opus-5")   # no inferenceConfig at all
→ stopReason=max_tokens  outputTokens=4096
```

A diagram of about 30 cells is roughly 3000 tokens of XML. Add a title, a legend and a few
lanes and it runs past 4096, so the tool call arrives as truncated JSON, nothing reaches the
canvas, and the reply comes back with no diagram in it.

What made this hard to spot: small diagrams still fitted. The same prompt succeeded or
produced an empty reply depending on how much the model wrote before the cut, so it read as
flakiness rather than a limit.

Reproduced with:

> 绘制一个git开发流程图：分支类型包含main分支，feature分支、hotfix分支、release分支和tag分支，通过流程图说明各个分支间的关系，体现开发、测试、维护的全流程

Before: `finishReason: "length"`, the XML cut off mid-attribute at 946 characters — the last
thing written was `fontColor` with no value after it. Empty reply on screen.

After: one tool call, the whole diagram — 27 cells, 10 edges.

## The change

`maxOutputTokens` is now always sent, defaulting to 16000 (roughly 150 cells with
commentary). `MAX_OUTPUT_TOKENS` still overrides it.

`env.example` documents the option, including the part that is easy to get wrong: leaving it
unset does not mean "the model's maximum".

## Not covered here

The default is a single number for every provider rather than per-model. A provider whose own
ceiling is below 16000 would reject the request instead of quietly truncating — which is at
least a visible failure rather than a silent one, but it is a real limitation worth naming.
