### PR TITLE
feat: optimize get_shape_library with LLM-based shape filtering

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import {
     generateText,
     InvalidToolInputError,
     LoadAPIKeyError,
+    Output,
     stepCountIs,
     streamText,
 } from "ai"
@@ -36,6 +37,14 @@ import {
     wrapWithObserve,
 } from "@/lib/langfuse"
 import { findServerModelById } from "@/lib/server-model-config"
+import {
+    extractUserPrompt,
+    MAX_FILTERED_SHAPES,
+    parseShapeDoc,
+    rebuildShapeDoc,
+    SHAPE_FILTER_THRESHOLD,
+    selectShapes,
+} from "@/lib/shape-library-filter"
 import { getSystemPrompt } from "@/lib/system-prompts"
 import { getUserIdFromRequest } from "@/lib/user-id"
 
@@ -113,8 +122,6 @@ async function handleChatRequest(req: Request): Promise<Response> {
         .find((m: any) => m.role === "user")
     const userInputText =
         lastUserMessage?.parts?.find((p: any) => p.type === "text")?.text || ""
-
-    ;(globalThis as any).lastUserInputText = userInputText
 
     // Update Langfuse trace with input, session, and user
     setTraceInput({
@@ -722,7 +729,7 @@ Call this tool to get shape names and usage syntax for a specific library.`,
                             "Library name (e.g., 'aws4', 'kubernetes', 'flowchart')",
                         ),
                 }),
-                execute: async ({ library }) => {
+                execute: async ({ library }, { messages, abortSignal }) => {
                     // Sanitize input - prevent path traversal attacks
                     const sanitizedLibrary = library
                         .toLowerCase()
@@ -748,51 +755,70 @@ Call this tool to get shape names and usage syntax for a specific library.`,
                     }
 
                     try {
-                        const userPrompt =
-                            (globalThis as any).lastUserInputText || ""
-
                         const content = await fs.readFile(filePath, "utf-8")
 
-                        const [headerPart, shapesPart] =
-                            content.split("## Shapes")
-
-                        const shapes =
-                            shapesPart
-                                ?.split("\n")
-                                .filter((l) => l.startsWith("- "))
-                                .map((l) => l.replace("- ", "").trim()) || []
-
-                        if (shapes.length < 100) return content
-
-                        const { text } = await generateText({
-                            model,
-                            temperature: 0,
-                            prompt: `
-                    User request: "${userPrompt}"
-
-                    Pick only the 15 most relevant shapes.
-                    Return ONLY JSON array.
-
-                    ${shapes.join("\n")}
-                     `,
-                        })
-
-                        let selected: string[] = []
-
-                        try {
-                            selected = JSON.parse(text)
-                        } catch {
-                            const match = text.match(/\[[\s\S]*\]/)
-                            if (match) {
-                                selected = JSON.parse(match[0])
-                            }
+                        // Large libraries are filtered down to the shapes
+                        // relevant to the user's request; everything else
+                        // (small libraries, unrecognized formats) is returned
+                        // in full.
+                        const parsed = parseShapeDoc(content)
+                        if (
+                            !parsed ||
+                            parsed.totalShapes < SHAPE_FILTER_THRESHOLD
+                        ) {
+                            return content
                         }
 
-                        return `
-                    ${headerPart}
+                        const userPrompt = extractUserPrompt(messages)
+                        if (!userPrompt) {
+                            return content
+                        }
 
-                    ## Shapes
-                    ${(selected as string[]).map((s: string) => `- ${s}`).join("\n")}   `
+                        // Secondary LLM call to pick the most relevant shapes.
+                        // On any failure (provider error, schema validation,
+                        // empty selection) we fall back to the full document -
+                        // never return zero shapes.
+                        let selected: string[] = []
+                        try {
+                            const { output } = await generateText({
+                                model,
+                                temperature: 0,
+                                maxOutputTokens: 2000,
+                                abortSignal,
+                                output: Output.object({
+                                    schema: z.object({
+                                        shapes: z
+                                            .array(z.string())
+                                            .describe(
+                                                "Most relevant shape names, copied exactly from the list",
+                                            ),
+                                    }),
+                                }),
+                                prompt: `You are helping build a draw.io diagram. From the shape list below, pick the ${MAX_FILTERED_SHAPES} most relevant shapes for the user's request.
+
+User request: "${userPrompt}"
+
+Shape list:
+${parsed.groups.flatMap((group) => group.shapes).join("\n")}
+
+Return only shape names that appear exactly in the list.`,
+                            })
+                            selected = selectShapes(
+                                parsed,
+                                output?.shapes ?? [],
+                            )
+                        } catch (error) {
+                            console.error(
+                                `[get_shape_library] Shape filtering failed for "${library}", returning full library:`,
+                                error,
+                            )
+                        }
+
+                        if (selected.length === 0) {
+                            return content
+                        }
+
+                        return rebuildShapeDoc(parsed, selected)
                     } catch (error) {
                         if (
                             (error as NodeJS.ErrnoException).code === "ENOENT"

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,6 +3,7 @@ import {
     convertToModelMessages,
     createUIMessageStream,
     createUIMessageStreamResponse,
+    generateText,
     InvalidToolInputError,
     LoadAPIKeyError,
     stepCountIs,
@@ -112,6 +113,8 @@ async function handleChatRequest(req: Request): Promise<Response> {
         .find((m: any) => m.role === "user")
     const userInputText =
         lastUserMessage?.parts?.find((p: any) => p.type === "text")?.text || ""
+
+    ;(globalThis as any).lastUserInputText = userInputText
 
     // Update Langfuse trace with input, session, and user
     setTraceInput({
@@ -745,8 +748,51 @@ Call this tool to get shape names and usage syntax for a specific library.`,
                     }
 
                     try {
+                        const userPrompt =
+                            (globalThis as any).lastUserInputText || ""
+
                         const content = await fs.readFile(filePath, "utf-8")
-                        return content
+
+                        const [headerPart, shapesPart] =
+                            content.split("## Shapes")
+
+                        const shapes =
+                            shapesPart
+                                ?.split("\n")
+                                .filter((l) => l.startsWith("- "))
+                                .map((l) => l.replace("- ", "").trim()) || []
+
+                        if (shapes.length < 100) return content
+
+                        const { text } = await generateText({
+                            model,
+                            temperature: 0,
+                            prompt: `
+                    User request: "${userPrompt}"
+
+                    Pick only the 15 most relevant shapes.
+                    Return ONLY JSON array.
+
+                    ${shapes.join("\n")}
+                     `,
+                        })
+
+                        let selected: string[] = []
+
+                        try {
+                            selected = JSON.parse(text)
+                        } catch {
+                            const match = text.match(/\[[\s\S]*\]/)
+                            if (match) {
+                                selected = JSON.parse(match[0])
+                            }
+                        }
+
+                        return `
+                    ${headerPart}
+
+                    ## Shapes
+                    ${(selected as string[]).map((s: string) => `- ${s}`).join("\n")}   `
                     } catch (error) {
                         if (
                             (error as NodeJS.ErrnoException).code === "ENOENT"

--- a/lib/shape-library-filter.ts
+++ b/lib/shape-library-filter.ts
@@ -1,0 +1,204 @@
+import type { ModelMessage, TextPart } from "ai"
+
+/**
+ * Libraries with at least this many shapes are filtered down via a secondary
+ * LLM call. Smaller libraries are returned in full.
+ */
+export const SHAPE_FILTER_THRESHOLD = 100
+
+/** Maximum number of shapes kept after LLM filtering. */
+export const MAX_FILTERED_SHAPES = 15
+
+export interface ShapeGroup {
+    /** Verbatim `### ...` heading line, or null for flat (uncategorized) lists */
+    heading: string | null
+    /** Shape names with backticks and surrounding whitespace stripped */
+    shapes: string[]
+}
+
+export interface ParsedShapeDoc {
+    /** Everything before the `## Shapes` heading */
+    header: string
+    /** Non-empty lines between the `## Shapes` heading and the first shape/section */
+    intro: string[]
+    groups: ShapeGroup[]
+    totalShapes: number
+}
+
+const SHAPE_LINE = /^-\s+(?:`([^`]+)`|(\S+))\s*$/
+const HEADING_LINE = /^###\s+.+/
+const H2_CATEGORY_LINE = /^##\s+\S+\s*\(\d+\)\s*$/
+const INLINE_CATEGORY_LINE = /^-\s+\*\*(.+?)\*\*\s*\(\d+\):\s*(.+)$/
+const HEADING_COUNT = /\s*\(\d+\)\s*$/
+
+/**
+ * Parse a shape library markdown doc. Supports flat shape lists (aws4, gcp2,
+ * ...), `### category` sections (azure2), inline `- **category** (N): a, b, c`
+ * entries (azure2), and `## category (N)` sections without a central
+ * `## Shapes` heading (material_design). Returns null when the doc has no
+ * parseable shape list.
+ */
+export function parseShapeDoc(content: string): ParsedShapeDoc | null {
+    let header: string
+    let bodyLines: string[]
+    let isCategoryHeading: (line: string) => boolean
+
+    const shapesIdx = content.indexOf("## Shapes")
+    if (shapesIdx !== -1) {
+        header = content.slice(0, shapesIdx).trimEnd()
+        // Skip index 0: the "## Shapes" heading line itself
+        bodyLines = content.slice(shapesIdx).split("\n").slice(1)
+        isCategoryHeading = (line) => HEADING_LINE.test(line)
+    } else {
+        // Fallback: docs like material_design split shapes across
+        // "## category (N)" sections without a central Shapes heading
+        const lines = content.split("\n")
+        const firstCategoryIdx = lines.findIndex((line, i) => {
+            if (!H2_CATEGORY_LINE.test(line)) return false
+            // must actually contain shape lines before the next heading
+            for (let j = i + 1; j < lines.length; j++) {
+                if (lines[j].startsWith("#")) return false
+                if (SHAPE_LINE.test(lines[j])) return true
+            }
+            return false
+        })
+        if (firstCategoryIdx === -1) return null
+        header = lines.slice(0, firstCategoryIdx).join("\n").trimEnd()
+        bodyLines = lines.slice(firstCategoryIdx)
+        isCategoryHeading = (line) => line.startsWith("## ")
+    }
+
+    const intro: string[] = []
+    const groups: ShapeGroup[] = []
+    let current: ShapeGroup | null = null
+    let totalShapes = 0
+
+    for (const line of bodyLines) {
+        const inlineCategory = line.match(INLINE_CATEGORY_LINE)
+        const shapeMatch = line.match(SHAPE_LINE)
+
+        if (inlineCategory) {
+            // azure2 packs small categories onto a single line:
+            // - **integration** (21): Name1, Name2, ...
+            const name = inlineCategory[1].trim()
+            const shapes = inlineCategory[2]
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean)
+            current = { heading: `### ${name} (${shapes.length})`, shapes }
+            groups.push(current)
+            totalShapes += shapes.length
+        } else if (shapeMatch) {
+            const name = (shapeMatch[1] ?? shapeMatch[2])?.trim()
+            if (!name) continue
+            if (!current) {
+                current = { heading: null, shapes: [] }
+                groups.push(current)
+            }
+            current.shapes.push(name)
+            totalShapes++
+        } else if (isCategoryHeading(line)) {
+            current = { heading: line.trim(), shapes: [] }
+            groups.push(current)
+        } else if (line.trim() !== "" && !current) {
+            // Intro text sits above the first shape or section heading
+            intro.push(line.trimEnd())
+        }
+        // Blank lines and stray text after shapes started are dropped;
+        // rebuildShapeDoc re-emits the doc with consistent spacing.
+    }
+
+    if (totalShapes === 0) return null
+    return { header, intro, groups, totalShapes }
+}
+
+/**
+ * Validate an LLM-selected shape list against the parsed doc. Drops
+ * hallucinated names, dedupes case-insensitively (keeping the canonical
+ * spelling), and caps the result at maxShapes. Returns names in the order the
+ * LLM ranked them.
+ */
+export function selectShapes(
+    parsed: ParsedShapeDoc,
+    selected: string[],
+    maxShapes: number = MAX_FILTERED_SHAPES,
+): string[] {
+    const canonical = new Map<string, string>()
+    for (const group of parsed.groups) {
+        for (const shape of group.shapes) {
+            const key = shape.toLowerCase()
+            if (!canonical.has(key)) canonical.set(key, shape)
+        }
+    }
+
+    const kept: string[] = []
+    const seen = new Set<string>()
+    for (const candidate of selected) {
+        const name = canonical.get(
+            candidate.trim().replace(/`/g, "").toLowerCase(),
+        )
+        if (!name || seen.has(name)) continue
+        seen.add(name)
+        kept.push(name)
+        if (kept.length >= maxShapes) break
+    }
+    return kept
+}
+
+/**
+ * Rebuild the markdown doc containing only the kept shapes. Category
+ * sections (azure2) are preserved with updated counts; empty sections are
+ * dropped. Shapes are re-emitted in document order within their section.
+ */
+export function rebuildShapeDoc(
+    parsed: ParsedShapeDoc,
+    kept: string[],
+): string {
+    const keptSet = new Set(kept)
+    const sections: string[] = []
+
+    for (const group of parsed.groups) {
+        const keptShapes = group.shapes.filter((shape) => keptSet.has(shape))
+        if (keptShapes.length === 0) continue
+
+        const lines = keptShapes.map((shape) => `- \`${shape}\``).join("\n")
+        if (group.heading) {
+            const heading = group.heading.replace(
+                HEADING_COUNT,
+                ` (${keptShapes.length})`,
+            )
+            sections.push(`${heading}\n\n${lines}`)
+        } else {
+            sections.push(lines)
+        }
+    }
+
+    const lines = [
+        parsed.header,
+        "",
+        `## Shapes (${kept.length} of ${parsed.totalShapes} - filtered for relevance)`,
+    ]
+    if (parsed.intro.length > 0) {
+        lines.push("", ...parsed.intro)
+    }
+    lines.push("", sections.join("\n\n"), "")
+    return lines.join("\n")
+}
+
+/**
+ * Extract the most recent user text from the model messages passed to a tool's
+ * execute function. Handles both string content and part arrays. Returns ""
+ * when no user text exists.
+ */
+export function extractUserPrompt(messages: ModelMessage[]): string {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i]
+        if (message.role !== "user") continue
+        if (typeof message.content === "string") return message.content
+        const textPart = message.content.find(
+            (part): part is TextPart => part.type === "text",
+        )
+        if (textPart?.text) return textPart.text
+    }
+    return ""
+}

--- a/tests/unit/shape-library-filter.test.ts
+++ b/tests/unit/shape-library-filter.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest"
+import {
+    extractUserPrompt,
+    MAX_FILTERED_SHAPES,
+    parseShapeDoc,
+    rebuildShapeDoc,
+    selectShapes,
+} from "@/lib/shape-library-filter"
+
+const FLAT_DOC = `# aws4
+
+**Type:** mxgraph shapes
+**Prefix:** \`mxgraph.aws4\`
+
+## Usage
+
+\`\`\`xml
+<mxCell style="shape=mxgraph.aws4.{shape}" />
+\`\`\`
+
+## Shapes (5)
+
+- \`lambda_function\`
+- \`s3_bucket\`
+- \`dynamodb_table\`
+- \`ec2_instance\`
+- \`rds_database\`
+`
+
+const CATEGORY_DOC = `# azure2
+
+**Type:** image shapes
+**Prefix:** \`img/lib/azure2/\`
+
+## Shapes (5)
+
+Shapes are organized by category: \`azure2/{category}/{shape}.svg\`
+
+### ai_machine_learning (3)
+
+- \`AI_Studio\`
+- \`Anomaly_Detector\`
+- \`Translator_Text\`
+
+### analytics (2)
+
+- \`Azure_Databricks\`
+- \`Analysis_Services\`
+`
+
+describe("parseShapeDoc", () => {
+    it("parses a flat shape list", () => {
+        const parsed = parseShapeDoc(FLAT_DOC)
+        expect(parsed).not.toBeNull()
+        expect(parsed?.header).toContain("# aws4")
+        expect(parsed?.header).toContain("## Usage")
+        expect(parsed?.totalShapes).toBe(5)
+        expect(parsed?.groups).toHaveLength(1)
+        expect(parsed?.groups[0].heading).toBeNull()
+        expect(parsed?.groups[0].shapes).toEqual([
+            "lambda_function",
+            "s3_bucket",
+            "dynamodb_table",
+            "ec2_instance",
+            "rds_database",
+        ])
+    })
+
+    it("parses a category-sectioned list with intro text", () => {
+        const parsed = parseShapeDoc(CATEGORY_DOC)
+        expect(parsed).not.toBeNull()
+        expect(parsed?.totalShapes).toBe(5)
+        expect(parsed?.groups).toHaveLength(2)
+        expect(parsed?.groups[0].heading).toBe("### ai_machine_learning (3)")
+        expect(parsed?.groups[0].shapes[0]).toBe("AI_Studio")
+        expect(parsed?.groups[1].heading).toBe("### analytics (2)")
+        expect(parsed?.intro).toHaveLength(1)
+        expect(parsed?.intro[0]).toContain("organized by category")
+    })
+
+    it("returns null when there is no Shapes section", () => {
+        expect(parseShapeDoc("# just a title\n\nsome text")).toBeNull()
+    })
+
+    it("returns null when no shape lines are present", () => {
+        expect(parseShapeDoc("# doc\n\n## Shapes\n\nNo shapes here")).toBeNull()
+    })
+})
+
+describe("selectShapes", () => {
+    it("keeps valid names and drops hallucinated ones", () => {
+        const parsed = parseShapeDoc(FLAT_DOC)!
+        const kept = selectShapes(parsed, [
+            "lambda_function",
+            "quantum_computer", // hallucinated
+            "s3_bucket",
+        ])
+        expect(kept).toEqual(["lambda_function", "s3_bucket"])
+    })
+
+    it("dedupes case-insensitively and canonicalizes spelling", () => {
+        const parsed = parseShapeDoc(CATEGORY_DOC)!
+        const kept = selectShapes(parsed, [
+            "ai_studio", // lowercase, should map to AI_Studio
+            "AI_Studio", // duplicate
+        ])
+        expect(kept).toEqual(["AI_Studio"])
+    })
+
+    it("caps the number of selected shapes", () => {
+        const parsed = parseShapeDoc(FLAT_DOC)!
+        const kept = selectShapes(
+            parsed,
+            [
+                "lambda_function",
+                "s3_bucket",
+                "dynamodb_table",
+                "ec2_instance",
+                "rds_database",
+            ],
+            2,
+        )
+        expect(kept).toEqual(["lambda_function", "s3_bucket"])
+        expect(MAX_FILTERED_SHAPES).toBe(15)
+    })
+
+    it("returns empty array when nothing matches", () => {
+        const parsed = parseShapeDoc(FLAT_DOC)!
+        expect(selectShapes(parsed, ["not_a_shape", "also_fake"])).toEqual([])
+    })
+})
+
+describe("rebuildShapeDoc", () => {
+    it("rebuilds a flat doc with the filtered heading and backticked names", () => {
+        const parsed = parseShapeDoc(FLAT_DOC)!
+        const doc = rebuildShapeDoc(parsed, ["lambda_function", "s3_bucket"])
+        expect(doc).toContain("## Shapes (2 of 5 - filtered for relevance)")
+        expect(doc).toContain("# aws4")
+        expect(doc).toContain("## Usage")
+        expect(doc).toContain("- `lambda_function`")
+        expect(doc).toContain("- `s3_bucket`")
+        expect(doc).not.toContain("dynamodb_table")
+    })
+
+    it("preserves category sections, drops empty ones, and updates counts", () => {
+        const parsed = parseShapeDoc(CATEGORY_DOC)!
+        const doc = rebuildShapeDoc(parsed, ["AI_Studio", "Analysis_Services"])
+        expect(doc).toContain("### ai_machine_learning (1)")
+        expect(doc).toContain("- `AI_Studio`")
+        expect(doc).toContain("### analytics (1)")
+        expect(doc).toContain("- `Analysis_Services`")
+        expect(doc).not.toContain("Translator_Text")
+        expect(doc).toContain("Shapes are organized by category")
+        expect(doc).toContain("## Shapes (2 of 5 - filtered for relevance)")
+    })
+
+    it("round-trips when all shapes are kept", () => {
+        const parsed = parseShapeDoc(CATEGORY_DOC)!
+        const doc = rebuildShapeDoc(
+            parsed,
+            parsed.groups.flatMap((g) => g.shapes),
+        )
+        for (const shape of parsed.groups.flatMap((g) => g.shapes)) {
+            expect(doc).toContain(`- \`${shape}\``)
+        }
+        expect(doc).toContain("## Shapes (5 of 5 - filtered for relevance)")
+    })
+})
+
+describe("extractUserPrompt", () => {
+    it("reads the last user message with string content", () => {
+        const messages = [
+            { role: "user", content: "first question" },
+            { role: "assistant", content: "answer" },
+            { role: "user", content: "draw me a cloud" },
+        ] as any[]
+        expect(extractUserPrompt(messages)).toBe("draw me a cloud")
+    })
+
+    it("reads text from a parts array and ignores files", () => {
+        const messages = [
+            {
+                role: "user",
+                content: [
+                    { type: "file", url: "data:image/png;base64,xxx" },
+                    { type: "text", text: "describe this image" },
+                ],
+            },
+        ] as any[]
+        expect(extractUserPrompt(messages)).toBe("describe this image")
+    })
+
+    it("returns empty string when there is no user message", () => {
+        const messages = [{ role: "assistant", content: "hello" }] as any[]
+        expect(extractUserPrompt(messages)).toBe("")
+    })
+})


### PR DESCRIPTION
Fixes #418

Rebased and reworked from #446 by @vansh-nagar (original commit `27fd552`) — all credit for the original idea and implementation goes to them. That branch had fallen 306 commits behind main; this PR carries the feature onto current main and addresses the review feedback from https://github.com/DayuanJiang/next-ai-draw-io/pull/446#issuecomment-3753669957.

## What it does

Large shape libraries (100+ shapes, e.g. aws4 with 1032) are filtered down to the ~15 shapes relevant to the user's request via a secondary LLM call, shrinking tool results from ~22KB to ~2KB. Smaller libraries are returned in full, unchanged.

## Review feedback addressed

| Feedback (from the #446 review) | Fix |
|---|---|
| `globalThis` shared across requests — one user's prompt could leak into another's filtering | Removed. The user prompt is now read from the tool's `{ messages }` execute option (`extractUserPrompt` in `lib/shape-library-filter.ts`), handling both string and parts-array content |
| If `generateText` fails or parsing returns nothing, the user gets zero shapes | Filtering is wrapped in try/catch and every failure path (provider error, schema validation, empty selection) falls back to returning the **full** library doc |
| LLM could hallucinate shape names | `selectShapes` validates every returned name against the parsed shape list (case-insensitive canonicalization), drops unknown names, dedupes, and caps at 15 |
| `Output.object()` with Zod would be cleaner than manual `JSON.parse` + regex | Now uses `generateText` with `output: Output.object({ schema: z.object({ shapes: z.array(z.string()) }) })` |

## Additional improvements over the original

- Parsing/rebuild logic extracted into `lib/shape-library-filter.ts` with unit tests (`tests/unit/shape-library-filter.test.ts`, 14 cases)
- Category-aware rebuild: `azure2` `### category` sections, its inline `- **category** (N): a, b, c` entries, and `material_design`'s `## category (N)` layout are preserved with updated counts instead of being flattened into one list
- `abortSignal` is passed to the secondary call so cancelled requests stop early
- Empty user prompt (e.g. image-only message) skips filtering and returns the full doc

## Commits

1. `feat: optimize get_shape_library with LLM-based shape filtering` — the original #446 commit rebased onto current main
2. `fix: address review feedback on shape library filtering` — the changes above

## Verification

- `npx tsc --noEmit` ✅
- `npm run check` (biome) ✅ — same exit status as main
- `npm run test -- --run` ✅ — 170/170 (incl. 14 new)
- `npm run build` ✅