### PR TITLE
fix: support DeepSeek V4 Vision image input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@ai-sdk/amazon-bedrock": "^4.0.1",
                 "@ai-sdk/anthropic": "^3.0.0",
                 "@ai-sdk/azure": "^3.0.0",
-                "@ai-sdk/deepseek": "^2.0.0",
+                "@ai-sdk/deepseek": "^2.0.62",
                 "@ai-sdk/gateway": "^3.0.0",
                 "@ai-sdk/google": "^3.0.0",
                 "@ai-sdk/google-vertex": "^4.0.16",
@@ -238,19 +238,58 @@
             }
         },
         "node_modules/@ai-sdk/deepseek": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.20.tgz",
-            "integrity": "sha512-MAL04sDTOWUiBjAGWaVgyeE4bYRb9QpKYRlIeCTZFga6I8yQs50XakhWEssrmvVihdpHGkqpDtCHsFqCydsWLA==",
+            "version": "2.0.62",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.62.tgz",
+            "integrity": "sha512-9gtHuDMxd/OIwb0x2M5vLQfhRTIKc3kfOq+QCXZBZSb4P0XR9cJanu3FTkH2zbgJvyUWpOwDq2rDGogQ5/Pn1w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.8",
-                "@ai-sdk/provider-utils": "4.0.15"
+                "@ai-sdk/provider": "3.0.15",
+                "@ai-sdk/provider-utils": "4.0.50"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider": {
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
+            "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider-utils": {
+            "version": "4.0.50",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.50.tgz",
+            "integrity": "sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.15",
+                "@standard-schema/spec": "^1.1.0",
+                "eventsource-parser": "^3.0.8",
+                "undici": "^6.28.0"
+            },
+            "engines": {
+                "node": ">=18.17"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/deepseek/node_modules/undici": {
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@ai-sdk/amazon-bedrock": "^4.0.1",
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/azure": "^3.0.0",
-        "@ai-sdk/deepseek": "^2.0.0",
+        "@ai-sdk/deepseek": "^2.0.62",
         "@ai-sdk/gateway": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/google-vertex": "^4.0.16",

--- a/tests/unit/deepseek-vision.test.ts
+++ b/tests/unit/deepseek-vision.test.ts
@@ -1,0 +1,90 @@
+import { createDeepSeek } from "@ai-sdk/deepseek"
+import { generateText } from "ai"
+import { describe, expect, it } from "vitest"
+
+describe("DeepSeek V4 Vision image input", () => {
+    it("includes image content in the chat completion request", async () => {
+        let requestBody:
+            | {
+                  messages: Array<{
+                      role: string
+                      content: string | Array<Record<string, unknown>>
+                  }>
+              }
+            | undefined
+
+        const provider = createDeepSeek({
+            apiKey: "test-key",
+            baseURL: "https://example.test",
+            fetch: async (_input, init) => {
+                const body = init?.body
+                const rawBody =
+                    typeof body === "string"
+                        ? body
+                        : new TextDecoder().decode(body as Uint8Array)
+                requestBody = JSON.parse(rawBody)
+
+                return new Response(
+                    JSON.stringify({
+                        id: "test-response",
+                        object: "chat.completion",
+                        created: 1,
+                        model: "deepseek-v4-flash-vision-exp",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "ok" },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 1,
+                            completion_tokens: 1,
+                            total_tokens: 2,
+                        },
+                    }),
+                    {
+                        status: 200,
+                        headers: { "content-type": "application/json" },
+                    },
+                )
+            },
+        })
+
+        await generateText({
+            model: provider("deepseek-v4-flash-vision-exp"),
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: "Describe this image." },
+                        {
+                            type: "image",
+                            image: "data:image/png;base64,aGVsbG8=",
+                            mediaType: "image/png",
+                        },
+                    ],
+                },
+            ],
+        })
+
+        if (requestBody === undefined) {
+            throw new Error("DeepSeek request was not captured")
+        }
+
+        const userMessage = requestBody.messages.find(
+            (message) => message.role === "user",
+        )
+        expect(userMessage?.content).toEqual(
+            expect.arrayContaining([
+                { type: "text", text: "Describe this image." },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "data:image/png;base64,aGVsbG8=",
+                    },
+                },
+            ]),
+        )
+    })
+})


### PR DESCRIPTION
## Summary

- Upgrade `@ai-sdk/deepseek` from `2.0.20` to `2.0.62`, which includes image-input support for `deepseek-v4-flash-vision-exp`.
- Add a regression test that captures the provider request and verifies that the image is serialized as an `image_url` part.

## Problem

When `deepseek-v4-flash-vision-exp` is selected, an image can appear correctly in the chat UI after being pasted or uploaded, but the model responds as if no image was provided.

### Reproduction

1. Select the DeepSeek provider and the `deepseek-v4-flash-vision-exp` model.
2. Paste or upload a PNG image in the chat panel.
3. Send a prompt such as `Describe this image.`.
4. Observe that the model does not receive the image and responds as if the request were text-only.

## Root cause

The chat route correctly preserves the attachment and passes it into the AI SDK message. In the current dependency set, however, `@ai-sdk/deepseek@2.0.20` only serializes text parts in its chat-message converter. The AI SDK presents the image attachment to that provider as a `file` part, which the old adapter warns about and then drops. The resulting DeepSeek request contains only the text content.

This is therefore a provider-adapter version issue, not a paste/upload UI issue. The fix does not restore model-name heuristics; provider capability handling remains delegated to the provider adapter.

## Changes

- Update the direct `@ai-sdk/deepseek` dependency and lockfile to `2.0.62`.
- Add `tests/unit/deepseek-vision.test.ts`, using a mocked fetch implementation to assert the exact outbound request for `deepseek-v4-flash-vision-exp`.

## Verification

Passing checks:

- `npm ci --no-audit --no-fund`
- `npx vitest run tests/unit/deepseek-vision.test.ts tests/unit/ai-providers.test.ts` — 30/30 passed
- `npx tsc --noEmit`
- `npx biome check tests/unit/deepseek-vision.test.ts`
- `npm run build`
- `git diff --check upstream/main...HEAD`

Repository baseline limitations observed during verification:

- `npm run test -- --run` — 173 passed, 2 failed in the existing Windows permission assumptions in `tests/unit/admin-settings.test.ts`.
- `npm run test:e2e` — 52 passed, 2 skipped, 11 failed. The failures were existing draw.io iframe visibility or `networkidle` waits; no DeepSeek provider assertion is covered by this UI suite.
- `npm run check` — existing repository-wide Biome configuration/schema and unrelated-file findings remain outside this change.
- `npm --prefix packages/mcp-server test` — 70 passed, 3 skipped, but the suite exits on the existing Windows `spawn EINVAL` server-wiring setup.

The new regression test and all directly affected checks pass.