### PR TITLE
feat: add GLM Coding Plan provider (glm-coding)

### DIFF
--- a/app/api/validate-model/route.ts
+++ b/app/api/validate-model/route.ts
@@ -13,6 +13,7 @@ import { createOllama } from "ollama-ai-provider-v2"
 import {
     AIHUBMIX_APP_CODE,
     isAihubmixStandardBaseURL,
+    normalizeGLMBaseURL,
     normalizeMiniMaxBaseURL,
 } from "@/lib/ai-providers"
 import { allowPrivateUrls, isPrivateUrl } from "@/lib/ssrf-protection"
@@ -372,8 +373,33 @@ export async function POST(req: Request) {
                 break
             }
 
-            // GLM, Qwen, Kimi, Qiniu, Novita, MiMo, Atlas Cloud - OpenAI compatible
             case "glm":
+            case "glm-coding": {
+                const rawUrl =
+                    baseUrl ||
+                    PROVIDER_INFO[provider as ProviderName]?.defaultBaseUrl ||
+                    "https://open.bigmodel.cn/api/paas/v4"
+                const { baseURL: glmBaseUrl, isAnthropicCompatible } =
+                    normalizeGLMBaseURL(rawUrl)
+
+                if (isAnthropicCompatible) {
+                    // GLM Coding Plan Anthropic-compatible endpoint
+                    const glm = createAnthropic({
+                        apiKey,
+                        baseURL: glmBaseUrl,
+                    })
+                    model = glm.chat(modelId)
+                } else {
+                    const glm = createOpenAI({
+                        apiKey,
+                        baseURL: glmBaseUrl,
+                    })
+                    model = glm.chat(modelId)
+                }
+                break
+            }
+
+            // Qwen, Kimi, Qiniu, Novita, Atlas Cloud, MiMo - OpenAI compatible
             case "qwen":
             case "kimi":
             case "qiniu":

--- a/docs/cn/ai-providers.md
+++ b/docs/cn/ai-providers.md
@@ -269,6 +269,22 @@ AI_MODEL=glm-4
 GLM_BASE_URL=https://your-custom-endpoint
 ```
 
+### GLM Coding Plan (智谱编程套餐)
+
+GLM Coding Plan（编程套餐）专属端点，套餐 Key 在通用按量端点上无效：
+
+```bash
+GLM_CODING_API_KEY=your_coding_plan_api_key
+AI_PROVIDER=glm-coding
+AI_MODEL=glm-5.3
+```
+
+可选端点（Anthropic 兼容协议）：
+
+```bash
+GLM_CODING_BASE_URL=https://open.bigmodel.cn/api/anthropic
+```
+
 ### Qwen (阿里云通义千问)
 
 ```bash
@@ -328,7 +344,7 @@ MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
 如果您配置了**多个** API 密钥，则必须显式设置 `AI_PROVIDER`：
 
 ```bash
-AI_PROVIDER=google  # 或：openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, qwen, kimi, qiniu, mimo
+AI_PROVIDER=google  # 或：openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, glm-coding, qwen, kimi, qiniu, mimo
 ```
 
 ## 服务端多模型配置

--- a/docs/en/ai-providers.md
+++ b/docs/en/ai-providers.md
@@ -284,6 +284,22 @@ Optional custom endpoint:
 GLM_BASE_URL=https://your-custom-endpoint
 ```
 
+### GLM Coding Plan (Zhipu)
+
+Dedicated endpoint for GLM Coding Plan subscribers - plan keys do NOT work on the general pay-as-you-go endpoint:
+
+```bash
+GLM_CODING_API_KEY=your_coding_plan_api_key
+AI_PROVIDER=glm-coding
+AI_MODEL=glm-5.3
+```
+
+Optional endpoint (Anthropic-compatible protocol):
+
+```bash
+GLM_CODING_BASE_URL=https://open.bigmodel.cn/api/anthropic
+```
+
 ### Qwen (Alibaba Cloud)
 
 ```bash
@@ -343,7 +359,7 @@ If you only configure **one** provider's API key, the system will automatically 
 If you configure **multiple** API keys, you must explicitly set `AI_PROVIDER`:
 
 ```bash
-AI_PROVIDER=google  # or: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, qwen, kimi, qiniu, mimo
+AI_PROVIDER=google  # or: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, glm-coding, qwen, kimi, qiniu, mimo
 ```
 
 ## Server-Side Multi-Model Configuration

--- a/docs/ja/ai-providers.md
+++ b/docs/ja/ai-providers.md
@@ -269,6 +269,22 @@ AI_MODEL=glm-4
 GLM_BASE_URL=https://your-custom-endpoint
 ```
 
+### GLM Coding Plan (Zhipu)
+
+GLM Coding Plan（プログラミングプラン）専用エンドポイント。プランのキーは汎用の従量課金エンドポイントでは利用できません：
+
+```bash
+GLM_CODING_API_KEY=your_coding_plan_api_key
+AI_PROVIDER=glm-coding
+AI_MODEL=glm-5.3
+```
+
+オプションのエンドポイント（Anthropic 互換プロトコル）：
+
+```bash
+GLM_CODING_BASE_URL=https://open.bigmodel.cn/api/anthropic
+```
+
 ### Qwen (Alibaba Cloud)
 
 ```bash
@@ -328,7 +344,7 @@ MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
 **複数**の API キーを設定する場合は、`AI_PROVIDER` を明示的に設定する必要があります:
 
 ```bash
-AI_PROVIDER=google  # または: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, qwen, kimi, qiniu, mimo
+AI_PROVIDER=google  # または: openai, anthropic, aihubmix, deepseek, siliconflow, doubao, azure, bedrock, openrouter, ollama, gateway, sglang, modelscope, minimax, glm, glm-coding, qwen, kimi, qiniu, mimo
 ```
 
 ## サーバーサイドマルチモデル設定

--- a/env.example
+++ b/env.example
@@ -175,6 +175,13 @@ AI_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 # GLM_API_KEY=your_glm_api_key
 # GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4  # Optional, default
 
+# GLM Coding Plan Configuration (Optional)
+# GLM Coding Plan subscription endpoint - plan keys do NOT work on the
+# general pay-as-you-go endpoint above.
+# Get your Coding Plan API key from: https://docs.bigmodel.cn/cn/coding-plan/quick-start
+# GLM_CODING_API_KEY=your_glm_coding_plan_api_key
+# GLM_CODING_BASE_URL=https://open.bigmodel.cn/api/coding/paas/v4  # Optional, default (OpenAI). Anthropic-compatible: https://open.bigmodel.cn/api/anthropic
+
 # Qwen Configuration (Optional)
 # Get your API key from: https://www.aliyun.com/product/bailian
 # QWEN_API_KEY=your_qwen_api_key

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -28,6 +28,7 @@ interface ModelConfig {
 export const SINGLE_SYSTEM_PROVIDERS = new Set<ProviderName>([
     "minimax",
     "glm",
+    "glm-coding",
     "qwen",
     "kimi",
     "qiniu",
@@ -57,6 +58,25 @@ export function normalizeMiniMaxBaseURL(rawUrl: string): {
         if (!baseURL.endsWith("/v1")) {
             baseURL = `${baseURL}/v1`
         }
+    }
+    return { baseURL, isAnthropicCompatible }
+}
+
+/**
+ * Normalize GLM (Zhipu) base URL for AI SDK compatibility.
+ * GLM Coding Plan supports Anthropic-compatible and OpenAI-compatible endpoints.
+ * OpenAI endpoints (https://open.bigmodel.cn/api/paas/v4 and
+ * https://open.bigmodel.cn/api/coding/paas/v4) are used as-is, while the
+ * Anthropic endpoint gets a /v1 suffix since the SDK appends /messages.
+ */
+export function normalizeGLMBaseURL(rawUrl: string): {
+    baseURL: string
+    isAnthropicCompatible: boolean
+} {
+    const isAnthropicCompatible = rawUrl.includes("/anthropic")
+    let baseURL = rawUrl.replace(/\/$/, "")
+    if (isAnthropicCompatible && !baseURL.endsWith("/v1")) {
+        baseURL = `${baseURL}/v1`
     }
     return { baseURL, isAnthropicCompatible }
 }
@@ -112,6 +132,7 @@ const ALLOWED_CLIENT_PROVIDERS: ProviderName[] = [
     "doubao",
     "modelscope",
     "glm",
+    "glm-coding",
     "qwen",
     "qiniu",
     "kimi",
@@ -540,6 +561,7 @@ function buildProviderOptions(
         case "doubao":
         case "minimax":
         case "glm":
+        case "glm-coding":
         case "qwen":
         case "kimi":
         case "qiniu":
@@ -577,6 +599,7 @@ export const PROVIDER_ENV_VARS: Record<ProviderName, string | null> = {
     doubao: "DOUBAO_API_KEY",
     modelscope: "MODELSCOPE_API_KEY",
     glm: "GLM_API_KEY",
+    "glm-coding": "GLM_CODING_API_KEY",
     qwen: "QWEN_API_KEY",
     qiniu: "QINIU_API_KEY",
     kimi: "KIMI_API_KEY",
@@ -1353,6 +1376,51 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
             break
         }
 
+        case "glm":
+        case "glm-coding": {
+            // glm-coding targets the GLM Coding Plan subscription endpoint
+            // (https://open.bigmodel.cn/api/coding/paas/v4); plain glm targets
+            // the pay-as-you-go endpoint (https://open.bigmodel.cn/api/paas/v4).
+            const apiKey = resolveApiKey(
+                overrides,
+                PROVIDER_ENV_VARS[provider] as string,
+            )
+            const baseUrlEnvVar =
+                provider === "glm-coding"
+                    ? "GLM_CODING_BASE_URL"
+                    : "GLM_BASE_URL"
+            const rawBaseURL = resolveBaseURL(
+                overrides?.apiKey,
+                overrides?.baseUrl,
+                resolveBaseUrlEnv(overrides, baseUrlEnvVar),
+                PROVIDER_INFO[provider]?.defaultBaseUrl,
+            )
+
+            if (!rawBaseURL) {
+                throw new Error(
+                    `GLM base URL could not be resolved. Set ${baseUrlEnvVar} or configure a base URL in settings.`,
+                )
+            }
+
+            const { baseURL, isAnthropicCompatible } =
+                normalizeGLMBaseURL(rawBaseURL)
+
+            if (isAnthropicCompatible) {
+                // GLM Coding Plan Anthropic-compatible endpoint
+                const glm = createAnthropic({ apiKey, baseURL })
+                model = glm.chat(modelId)
+            } else {
+                // Use createDeepSeek to properly handle reasoning_content for
+                // GLM thinking models (e.g., glm-5.3). GLM's API uses the same
+                // reasoning_content field as DeepSeek and Kimi, so this
+                // provider correctly captures and replays reasoning in
+                // multi-turn conversations.
+                const glm = createDeepSeek({ apiKey, baseURL })
+                model = glm(modelId)
+            }
+            break
+        }
+
         case "mimo": {
             const apiKey = resolveApiKey(overrides, "MIMO_API_KEY")
             const baseURL = resolveBaseURL(
@@ -1370,7 +1438,6 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
             break
         }
 
-        case "glm":
         case "qwen":
         case "qiniu":
         case "novita":
@@ -1418,7 +1485,7 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
 
         default:
             throw new Error(
-                `Unknown AI provider: ${provider}. Supported providers: bedrock, openai, anthropic, google, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, sglang, gateway, edgeone, doubao, modelscope, glm, qwen, qiniu, kimi, minimax, novita, mimo, atlascloud`,
+                `Unknown AI provider: ${provider}. Supported providers: bedrock, openai, anthropic, google, azure, ollama, openrouter, aihubmix, deepseek, siliconflow, sglang, gateway, edgeone, doubao, modelscope, glm, glm-coding, qwen, qiniu, kimi, minimax, novita, mimo, atlascloud`,
             )
     }
 

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -32,6 +32,7 @@
         "modelscope": "ModelScope",
         "minimax": "MiniMax",
         "glm": "GLM",
+        "glm-coding": "GLM Coding Plan (Zhipu)",
         "qwen": "Qwen",
         "kimi": "Kimi",
         "qiniu": "Qiniu",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -32,6 +32,7 @@
         "modelscope": "ModelScope",
         "minimax": "MiniMax",
         "glm": "GLM",
+        "glm-coding": "GLM Coding Plan（Zhipu）",
         "qwen": "Qwen",
         "kimi": "Kimi",
         "qiniu": "Qiniu",

--- a/lib/i18n/dictionaries/zh-Hant.json
+++ b/lib/i18n/dictionaries/zh-Hant.json
@@ -32,6 +32,7 @@
         "modelscope": "ModelScope",
         "minimax": "MiniMax",
         "glm": "GLM",
+        "glm-coding": "GLM Coding Plan（智譜編程套餐）",
         "qwen": "Qwen",
         "kimi": "Kimi",
         "qiniu": "Qiniu",

--- a/lib/i18n/dictionaries/zh.json
+++ b/lib/i18n/dictionaries/zh.json
@@ -32,6 +32,7 @@
         "modelscope": "ModelScope",
         "minimax": "MiniMax",
         "glm": "GLM",
+        "glm-coding": "GLM Coding Plan（智谱编程套餐）",
         "qwen": "Qwen",
         "kimi": "Kimi",
         "qiniu": "Qiniu",

--- a/lib/types/model-config.ts
+++ b/lib/types/model-config.ts
@@ -18,6 +18,7 @@ export type ProviderName =
     | "doubao"
     | "modelscope"
     | "glm"
+    | "glm-coding"
     | "qwen"
     | "qiniu"
     | "kimi"
@@ -183,6 +184,10 @@ export const PROVIDER_INFO: Record<
     glm: {
         label: "GLM (Zhipu)",
         defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4",
+    },
+    "glm-coding": {
+        label: "GLM Coding Plan (Zhipu)",
+        defaultBaseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
     },
     qwen: {
         label: "Qwen (Alibaba)",
@@ -433,6 +438,13 @@ export const SUGGESTED_MODELS: Partial<Record<ProviderName, string[]>> = {
         "Qwen/Qwen3-Coder-30B-A3B-Instruct",
         "Qwen/Qwen3-32B",
         "Qwen/Qwen2.5-72B-Instruct",
+    ],
+    "glm-coding": [
+        // GLM Coding Plan models (https://docs.bigmodel.cn/cn/coding-plan/quick-start)
+        "glm-5.3",
+        "glm-5.2",
+        "glm-4.7",
+        "glm-4.5-air",
     ],
     minimax: [
         // MiniMax models (Anthropic-compatible API)

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
     getAIModel,
     isAihubmixStandardBaseURL,
+    normalizeGLMBaseURL,
     resolveBaseURL,
     supportsPromptCaching,
 } from "@/lib/ai-providers"
@@ -368,6 +369,113 @@ describe("Kimi provider uses createDeepSeek for reasoning_content support", () =
         expect(createDeepSeekMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 baseURL: "https://custom-kimi-endpoint.com/v1",
+            }),
+        )
+    })
+})
+
+describe("normalizeGLMBaseURL", () => {
+    it("normalizes the Anthropic-compatible endpoint by appending /v1", () => {
+        expect(
+            normalizeGLMBaseURL("https://open.bigmodel.cn/api/anthropic"),
+        ).toEqual({
+            baseURL: "https://open.bigmodel.cn/api/anthropic/v1",
+            isAnthropicCompatible: true,
+        })
+    })
+
+    it("keeps an already-normalized Anthropic endpoint unchanged", () => {
+        expect(
+            normalizeGLMBaseURL("https://open.bigmodel.cn/api/anthropic/v1/"),
+        ).toEqual({
+            baseURL: "https://open.bigmodel.cn/api/anthropic/v1",
+            isAnthropicCompatible: true,
+        })
+    })
+
+    it("uses OpenAI-compatible endpoints as-is", () => {
+        expect(
+            normalizeGLMBaseURL("https://open.bigmodel.cn/api/coding/paas/v4"),
+        ).toEqual({
+            baseURL: "https://open.bigmodel.cn/api/coding/paas/v4",
+            isAnthropicCompatible: false,
+        })
+        expect(
+            normalizeGLMBaseURL("https://open.bigmodel.cn/api/paas/v4"),
+        ).toEqual({
+            baseURL: "https://open.bigmodel.cn/api/paas/v4",
+            isAnthropicCompatible: false,
+        })
+    })
+})
+
+describe("GLM providers use createDeepSeek for reasoning_content support", () => {
+    let createDeepSeekMock: ReturnType<typeof vi.fn>
+    const savedEnv: Record<string, string | undefined> = {}
+
+    beforeEach(async () => {
+        savedEnv.GLM_API_KEY = process.env.GLM_API_KEY
+        savedEnv.GLM_BASE_URL = process.env.GLM_BASE_URL
+        savedEnv.GLM_CODING_API_KEY = process.env.GLM_CODING_API_KEY
+        savedEnv.GLM_CODING_BASE_URL = process.env.GLM_CODING_BASE_URL
+        delete process.env.GLM_BASE_URL
+        delete process.env.GLM_CODING_BASE_URL
+
+        const mod = await import("@ai-sdk/deepseek")
+        createDeepSeekMock = mod.createDeepSeek as ReturnType<typeof vi.fn>
+        createDeepSeekMock.mockClear()
+    })
+
+    afterEach(() => {
+        process.env.GLM_API_KEY = savedEnv.GLM_API_KEY
+        process.env.GLM_BASE_URL = savedEnv.GLM_BASE_URL
+        process.env.GLM_CODING_API_KEY = savedEnv.GLM_CODING_API_KEY
+        process.env.GLM_CODING_BASE_URL = savedEnv.GLM_CODING_BASE_URL
+    })
+
+    it("routes glm-coding to the Coding Plan endpoint with GLM_CODING_API_KEY", () => {
+        process.env.GLM_CODING_API_KEY = "server-coding-key"
+
+        getAIModel({
+            provider: "glm-coding",
+            modelId: "glm-5.3",
+        })
+
+        expect(createDeepSeekMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                apiKey: "server-coding-key",
+                baseURL: "https://open.bigmodel.cn/api/coding/paas/v4",
+            }),
+        )
+    })
+
+    it("routes plain glm to the pay-as-you-go endpoint with GLM_API_KEY", () => {
+        process.env.GLM_API_KEY = "server-glm-key"
+
+        getAIModel({
+            provider: "glm",
+            modelId: "glm-5.3",
+        })
+
+        expect(createDeepSeekMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                apiKey: "server-glm-key",
+                baseURL: "https://open.bigmodel.cn/api/paas/v4",
+            }),
+        )
+    })
+
+    it("supports client BYOK override for glm-coding", () => {
+        getAIModel({
+            provider: "glm-coding",
+            apiKey: "client-coding-key",
+            modelId: "glm-5.3",
+        })
+
+        expect(createDeepSeekMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                apiKey: "client-coding-key",
+                baseURL: "https://open.bigmodel.cn/api/coding/paas/v4",
             }),
         )
     })


### PR DESCRIPTION
## Problem

GLM Coding Plan subscription keys only work on Zhipu's dedicated coding endpoints. On the general pay-as-you-go endpoint they fail with error `1113` (insufficient balance), so plan subscribers currently cannot use next-ai-draw-io with their plan key: the existing `glm` provider defaults to `https://open.bigmodel.cn/api/paas/v4` and requires manually editing the base URL.

## Solution

Add a dedicated **`glm-coding`** provider that defaults to the Coding Plan endpoint, following the existing per-provider conventions (cf. MiniMax dual-protocol handling, MiMo Token Plan endpoint):

- Default base URL: `https://open.bigmodel.cn/api/coding/paas/v4` (OpenAI-compatible)
- Also supports the Anthropic-compatible endpoint `https://open.bigmodel.cn/api/anthropic` via a new `normalizeGLMBaseURL()` helper (appends `/v1` for the Anthropic SDK path, mirroring `normalizeMiniMaxBaseURL`)
- Uses `createDeepSeek` so `reasoning_content` from GLM thinking models (glm-5.3 etc.) is replayed in multi-turn conversations — same convention already used for Kimi/MiMo; the plain `glm` provider benefits too
- Env vars: `GLM_CODING_API_KEY` / `GLM_CODING_BASE_URL`
- Provider metadata, suggested models (glm-5.3 / glm-5.2 / glm-4.7 / glm-4.5-air), i18n labels (en / zh / zh-Hant / ja), `env.example` and docs (cn / en / ja) included

## Testing

- New unit tests for `normalizeGLMBaseURL` (Anthropic normalization, trailing slash, OpenAI passthrough) and provider routing (glm-coding → coding endpoint, glm → paas endpoint, BYOK override): 6 new cases, all passing
- `tsc --noEmit` and `biome lint` clean
- End-to-end verified against the real Coding Plan API via `/api/validate-model` for both the OpenAI-compatible and Anthropic-compatible endpoints (`{"valid":true}`), previously error 1113 with the same key
